### PR TITLE
chore: repo governance (CODEOWNERS, CLA, templates, SECURITY, CoC)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,15 +4,16 @@
 # matching path, and (with branch protection) their approval is REQUIRED before
 # merge. This is the primary "nothing merges without us" control.
 #
-# NOTE: add your co-maintainer's GitHub handle next to @VaradDurge below once
-# you have it (e.g. `* @VaradDurge @their-handle`). They must also be added as a
-# repo collaborator with at least "write"/"maintain" access for reviews to count.
+# Maintainers: @VaradDurge (owner) and @abhisheksharma001 (co-maintainer).
+# Both are added as repo collaborators so their reviews count toward the
+# required code-owner approval.
 
-# Default owner for everything in the repo.
-*                       @VaradDurge
+# Default owners for everything in the repo — either maintainer can approve
+# core changes.
+*                       @VaradDurge @abhisheksharma001
 
-# Proprietary / enterprise + release-critical paths — owner-only, never open to
-# external contribution.
+# Proprietary / enterprise + release-critical paths — OWNER-ONLY. These control
+# the business and licensing, so only @VaradDurge can approve changes here.
 /cloud/                 @VaradDurge
 /supabase/              @VaradDurge
 /LICENSE                @VaradDurge

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,23 @@
+# Code owners for ARGUS.
+#
+# Owners are automatically requested for review on any PR that touches a
+# matching path, and (with branch protection) their approval is REQUIRED before
+# merge. This is the primary "nothing merges without us" control.
+#
+# NOTE: add your co-maintainer's GitHub handle next to @VaradDurge below once
+# you have it (e.g. `* @VaradDurge @their-handle`). They must also be added as a
+# repo collaborator with at least "write"/"maintain" access for reviews to count.
+
+# Default owner for everything in the repo.
+*                       @VaradDurge
+
+# Proprietary / enterprise + release-critical paths — owner-only, never open to
+# external contribution.
+/cloud/                 @VaradDurge
+/supabase/              @VaradDurge
+/LICENSE                @VaradDurge
+/cloud/LICENSE          @VaradDurge
+/pyproject.toml         @VaradDurge
+/.github/               @VaradDurge
+/CODEOWNERS             @VaradDurge
+/.github/CODEOWNERS     @VaradDurge

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,57 @@
+name: Bug report
+description: Report a problem with ARGUS
+labels: ["bug", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug. Please fill in the details below.
+  - type: input
+    id: version
+    attributes:
+      label: ARGUS version
+      description: Output of `pip show argus-agents | grep Version` (or `argus --help` header).
+      placeholder: "0.8.11"
+    validations:
+      required: true
+  - type: dropdown
+    id: install
+    attributes:
+      label: How did you install it?
+      options:
+        - "pip install argus-agents (library only)"
+        - "pip install 'argus-agents[all]'"
+        - "pip install 'argus-agents[cli]'"
+        - "other / from source"
+    validations:
+      required: true
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: What did you expect, and what actually happened?
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: A minimal code snippet or commands that reproduce the issue.
+      render: shell
+    validations:
+      required: true
+  - type: input
+    id: env
+    attributes:
+      label: Environment
+      description: Python version, OS, LangGraph version (if used).
+      placeholder: "Python 3.11, macOS 14, langgraph 0.2.x"
+    validations:
+      required: false
+  - type: checkboxes
+    id: mode
+    attributes:
+      label: Detection mode
+      options:
+        - label: "Reproduces with BYOK / OPENAI_API_KEY set"
+        - label: "Reproduces in heuristic-only mode (no key)"

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/VaradDurge/ARGUS/security/advisories/new
+    about: Please report security issues privately, not as a public issue. See SECURITY.md.
+  - name: Hosted / enterprise support
+    url: https://arguslabs.in
+    about: Questions about the managed cloud tier, billing, or enterprise features.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,30 @@
+name: Feature request
+description: Suggest an idea or improvement for ARGUS
+labels: ["enhancement", "needs-triage"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: Describe the use case or pain point. What are you trying to do?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What would you like ARGUS to do?
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+    validations:
+      required: false
+  - type: checkboxes
+    id: scope
+    attributes:
+      label: Scope
+      options:
+        - label: "This is for the open-source core (not the hosted/enterprise tier)."

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,27 @@
+<!-- Thanks for contributing to ARGUS! Please fill this out. -->
+
+## What & why
+
+<!-- What does this PR change, and why? Link any related issue: Closes #123 -->
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Refactor / internal
+- [ ] Docs
+- [ ] Other:
+
+## Checklist
+
+- [ ] I have read the [Contributing guide](../CONTRIBUTING.md).
+- [ ] I have signed the [CLA](../CLA.md) (the bot will prompt on first PR).
+- [ ] My change targets the **open-source core** only — I have **not** modified
+      `cloud/` or `supabase/` (proprietary; maintainer-only).
+- [ ] Tests added/updated and `pytest` passes locally.
+- [ ] `ruff check .` passes.
+- [ ] Docs updated if behavior or the public API changed.
+
+## Notes for reviewers
+
+<!-- Anything that needs attention: tradeoffs, follow-ups, screenshots, etc. -->

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -36,7 +36,9 @@ jobs:
           path-to-signatures: 'signatures/cla.json'
           path-to-document: 'https://github.com/VaradDurge/ARGUS/blob/master/CLA.md'
           branch: 'cla-signatures'
-          # Maintainers are exempt from signing the CLA.
-          allowlist: VaradDurge,abhisheksharma001,bot*,dependabot*
+          # Only the owner/licensor is exempt. Co-maintainers who contribute code
+          # (e.g. @abhisheksharma001) sign the CLA too, so the owner retains
+          # relicensing rights over their contributions for the open-core model.
+          allowlist: VaradDurge,bot*,dependabot*
           custom-pr-sign-comment: 'I have read the CLA Document and I hereby sign the CLA'
           custom-allsigned-prcomment: 'All contributors have signed the CLA — thank you!'

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,42 @@
+name: CLA Assistant
+
+# Requires every external contributor to sign the CLA (CLA.md) before their PR can
+# be merged. Signatures are recorded in the `cla-signatures` branch of this repo.
+#
+# ONE-TIME SETUP (owner):
+#   1. Create a Personal Access Token (classic) with `repo` scope, or a
+#      fine-grained token with Contents: read/write on this repo.
+#   2. Add it as a repository secret named `CLA_SIGNATURES_TOKEN`
+#      (Settings → Secrets and variables → Actions → New repository secret).
+# The bot then comments on new PRs asking the contributor to sign.
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, closed, synchronize]
+
+permissions:
+  actions: write
+  contents: write
+  pull-requests: write
+  statuses: write
+
+jobs:
+  cla:
+    runs-on: ubuntu-latest
+    steps:
+      - name: CLA Assistant
+        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
+        uses: contributor-assistant/github-action@v2.6.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.CLA_SIGNATURES_TOKEN }}
+        with:
+          path-to-signatures: 'signatures/cla.json'
+          path-to-document: 'https://github.com/VaradDurge/ARGUS/blob/master/CLA.md'
+          branch: 'cla-signatures'
+          # Maintainers are exempt from signing. Add your co-maintainer's handle here.
+          allowlist: VaradDurge,bot*,dependabot*
+          custom-pr-sign-comment: 'I have read the CLA Document and I hereby sign the CLA'
+          custom-allsigned-prcomment: 'All contributors have signed the CLA — thank you!'

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -36,7 +36,7 @@ jobs:
           path-to-signatures: 'signatures/cla.json'
           path-to-document: 'https://github.com/VaradDurge/ARGUS/blob/master/CLA.md'
           branch: 'cla-signatures'
-          # Maintainers are exempt from signing. Add your co-maintainer's handle here.
-          allowlist: VaradDurge,bot*,dependabot*
+          # Maintainers are exempt from signing the CLA.
+          allowlist: VaradDurge,abhisheksharma001,bot*,dependabot*
           custom-pr-sign-comment: 'I have read the CLA Document and I hereby sign the CLA'
           custom-allsigned-prcomment: 'All contributors have signed the CLA — thank you!'

--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,63 @@
+# ARGUS Contributor License Agreement (CLA)
+
+Thank you for your interest in contributing to ARGUS ("the Project"), maintained
+by Varad Durge ("the Maintainer").
+
+To keep the Project sustainable as an **open-core** product — an Apache-2.0
+open-source core (`src/argus/`) alongside a proprietary hosted/enterprise layer
+(`cloud/`) — contributors must agree to the terms below. This lets the Maintainer
+continue to offer the core under Apache-2.0 **and** license the Project (including
+your contribution, as part of the core) under commercial terms for the hosted
+product.
+
+By submitting a contribution (a pull request, patch, or any code, documentation,
+or other material) to this repository, you agree to the following:
+
+## 1. Definitions
+
+- **"Contribution"** means any original work of authorship, including any
+  modifications or additions to existing work, that you intentionally submit to
+  the Project.
+- **"You"** means the individual or legal entity making the Contribution.
+
+## 2. Copyright License
+
+You grant the Maintainer, and recipients of software distributed by the
+Maintainer, a **perpetual, worldwide, non-exclusive, royalty-free, irrevocable**
+copyright license to reproduce, prepare derivative works of, publicly display,
+publicly perform, sublicense, and distribute your Contribution and such
+derivative works, **under any license terms, including both open-source
+(Apache-2.0) and proprietary/commercial licenses.**
+
+## 3. Patent License
+
+You grant the Maintainer and recipients a perpetual, worldwide, non-exclusive,
+royalty-free, irrevocable (except as stated below) patent license to make, use,
+sell, offer to sell, import, and otherwise transfer your Contribution, where such
+license applies only to patent claims licensable by you that are necessarily
+infringed by your Contribution alone or by combination with the Project.
+
+## 4. You Represent That
+
+- Each Contribution is your **original creation** and you have the right to grant
+  the licenses above.
+- If your employer has rights to intellectual property you create, you have
+  received permission to make the Contribution on behalf of that employer, or the
+  employer has waived such rights.
+- Your Contribution does not knowingly violate any third-party rights.
+
+## 5. No Obligation
+
+You understand the Maintainer is under no obligation to use or incorporate your
+Contribution. Contributions are provided "as is", without warranty of any kind.
+
+## 6. Scope
+
+This agreement covers the open-source core only. The `cloud/` directory and other
+proprietary components are **not** open to external contribution.
+
+---
+
+**How to sign:** the CLA-assistant bot will ask you to sign on your first pull
+request by commenting on it. Signing is a one-time action recorded against your
+GitHub account.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,42 @@
+# Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and maintainers pledge to make participation in the
+ARGUS community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment:
+
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Focusing on what is best for the community and the project
+
+Unacceptable behavior includes:
+
+- Harassment, insults, or derogatory comments, and personal or political attacks
+- Publishing others' private information without explicit permission
+- Trolling or deliberately disruptive behavior
+- Other conduct which could reasonably be considered inappropriate
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the maintainer at **varaddurge@gmail.com**. All complaints will be
+reviewed and investigated promptly and fairly. The maintainer is obligated to
+respect the privacy and security of the reporter of any incident.
+
+Maintainers have the right to remove, edit, or reject comments, commits, code,
+issues, and other contributions that are not aligned with this Code of Conduct,
+and to ban temporarily or permanently any contributor for behaviors they deem
+inappropriate, threatening, offensive, or harmful.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org),
+version 2.1.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -127,3 +127,24 @@ For bug reports, include:
 - Keep PRs focused — one fix or feature per PR
 - For new detection logic, include a fixture run that the old code misses and the new code catches
 - Don't add co-author attribution in commits
+
+## Contribution Terms (CLA)
+
+ARGUS is **open-core**: the core in `src/argus/` is Apache-2.0, while `cloud/`
+and `supabase/` are proprietary. To keep this model workable, first-time
+contributors must sign our lightweight [Contributor License Agreement](CLA.md).
+A bot will prompt you on your first pull request — signing is a one-time comment.
+
+The `cloud/` and `supabase/` directories are **not open to external
+contributions**. PRs that modify them will be closed.
+
+## Review & Merge Process
+
+- `master` is protected: **all changes land via pull request** — no direct pushes.
+- CI (ruff + pytest on Python 3.9/3.11/3.12) must pass.
+- At least one **code owner** approval is required (see [CODEOWNERS](.github/CODEOWNERS)).
+- Only maintainers merge to `master`.
+
+## Reporting Security Issues
+
+Do not open a public issue. Follow [SECURITY.md](SECURITY.md).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,28 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+**Please do not report security vulnerabilities through public GitHub issues.**
+
+Report privately via GitHub's [security advisory form](https://github.com/VaradDurge/ARGUS/security/advisories/new),
+or by email to **varaddurge@gmail.com** with the subject line `ARGUS SECURITY`.
+
+Please include:
+
+- A description of the issue and its impact
+- Steps to reproduce (a minimal proof-of-concept if possible)
+- Affected version(s) and environment
+
+You will get an acknowledgement within **72 hours**, and we will keep you updated
+on the fix and disclosure timeline. Please give us a reasonable window to release
+a fix before any public disclosure.
+
+## Supported versions
+
+Security fixes are applied to the latest released version of `argus-agents` on
+PyPI. Please upgrade to the latest version before reporting.
+
+## Scope
+
+This policy covers the open-source core (`src/argus/`). For issues in the hosted
+service, contact the maintainer directly at the email above.


### PR DESCRIPTION
Sets up open-core governance so nothing merges or relicenses without maintainer sign-off.

- CODEOWNERS — maintainer required-reviewer on everything; cloud/, supabase/, LICENSE, pyproject.toml, .github/ owner-locked
- CLA (CLA.md + cla.yml) — contributors grant relicensing rights (open-core dual-licensing); bot enforces on PRs
- PR + issue templates, SECURITY.md, CODE_OF_CONDUCT.md
- CONTRIBUTING.md — CLA, review process, cloud/ off-limits to external PRs

Follow-ups (owner): add co-maintainer to CODEOWNERS + as collaborator; create CLA_SIGNATURES_TOKEN secret; enable strict branch protection.