### PR TITLE
Open-core separation + BYOK (VAR-93)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,52 +1,210 @@
+ARGUS is open-core. The open-source core in src/argus/ is licensed under the
+Apache License, Version 2.0 (below). The cloud/ directory (hosted/enterprise
+components) is proprietary and licensed separately — see cloud/LICENSE.
+
 Copyright (c) 2026 Varad Durge
 
-All rights reserved.
+--------------------------------------------------------------------------------
 
-Permission is hereby granted to any person obtaining a copy of this software
-and associated documentation files (the "Software") to use, copy, and modify
-the Software for non-commercial purposes only, subject to the following
-conditions:
 
-1. Attribution Requirement
-   Any use, distribution, or modification of the Software must include proper
-   attribution to the original author, Varad Durge, including this copyright
-   notice in all copies or substantial portions of the Software.
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-2. Non-Commercial Use Only
-   The Software may not be used, in whole or in part, for commercial purposes
-   without prior written permission from the author. Commercial purposes
-   include, but are not limited to, incorporating the Software into a product
-   or service that is sold, licensed for a fee, or used to generate revenue.
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-3. No Redistribution Without Permission
-   Redistribution of the Software, with or without modification, whether for
-   commercial or non-commercial purposes, is strictly prohibited without
-   prior written permission from the author. This includes, but is not
-   limited to, selling, sublicensing, giving away, bundling, publishing
-   forks, or making the Software (or any derivative work) available to
-   third parties through any channel.
+   1. Definitions.
 
-   For clarity: forking the repository for personal, private use is
-   permitted. Publishing or distributing that fork — even for free — is not.
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
 
-4. Derivative Works
-   Any derivative work based on the Software is subject to the same
-   restrictions as the original Software. Derivative works may not be
-   distributed, published, or made available to third parties without
-   prior written permission from the author.
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
 
-5. Commercial Licensing
-   Any commercial use or redistribution of the Software requires a
-   separate paid license or explicit written permission from the author.
-   Contact: varaddurge@gmail.com
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
 
-6. No Warranty
-   The Software is provided "as is", without warranty of any kind, express or
-   implied, including but not limited to the warranties of merchantability,
-   fitness for a particular purpose, and noninfringement.
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
 
-7. Limitation of Liability
-   In no event shall the author be liable for any claim, damages, or other
-   liability, whether in an action of contract, tort, or otherwise, arising
-   from, out of, or in connection with the Software or the use of or other
-   dealings in the Software.
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -17,10 +17,24 @@ Your LangGraph pipeline runs fine — no exception. But three nodes later, somet
 ## Install
 
 ```bash
-pip install argus-agents
+pip install "argus-agents[all]"
 ```
 
-That's the whole product. ARGUS runs **fully local** — runs are stored in `.argus/runs/`, no account, no cloud, no signup. Heuristic detection (150+ signatures) works out of the box.
+This gets the full product: the `argus` CLI, the LangGraph adapter, and AI-powered detection. ARGUS runs **fully local** — runs are stored in `.argus/runs/`, no account, no cloud, no signup. Heuristic detection (150+ signatures) works out of the box.
+
+<details>
+<summary>Installing only what you need</summary>
+
+`argus-agents` has a zero-dependency core. Pull in just the extras you use:
+
+```bash
+pip install argus-agents            # framework-agnostic library only (ArgusSession)
+pip install "argus-agents[cli]"     # + the `argus` command-line tool
+pip install "argus-agents[langgraph]"  # + the ArgusWatcher LangGraph adapter
+pip install "argus-agents[llm]"     # + OpenAI-powered semantic features
+pip install "argus-agents[all]"     # everything (recommended)
+```
+</details>
 
 ## Bring Your Own Key (BYOK)
 

--- a/README.md
+++ b/README.md
@@ -252,3 +252,9 @@ For AI setup prompts and integration guides, visit **[arguslabs.in](https://argu
 ---
 
 **v0.8.11** — [changelog](https://github.com/VaradDurge/ARGUS/releases)
+
+## License
+
+ARGUS is **open-core**. The open-source core (`src/argus/`, the `argus-agents` PyPI
+package) is licensed under **Apache-2.0** — see [LICENSE](LICENSE). The `cloud/`
+directory (hosted/enterprise components) is proprietary — see [cloud/LICENSE](cloud/LICENSE).

--- a/README.md
+++ b/README.md
@@ -20,6 +20,29 @@ Your LangGraph pipeline runs fine — no exception. But three nodes later, somet
 pip install argus-agents
 ```
 
+That's the whole product. ARGUS runs **fully local** — runs are stored in `.argus/runs/`, no account, no cloud, no signup. Heuristic detection (150+ signatures) works out of the box.
+
+## Bring Your Own Key (BYOK)
+
+AI-powered detection (the semantic judge, LLM investigator, learned trends) uses **your own** OpenAI key. Set it once and it's saved locally for every future session:
+
+```bash
+argus key set            # prompts, hidden input — saved to ~/.argus/config.json
+# or pass it directly:
+argus key set sk-...
+# or just export it:
+export OPENAI_API_KEY=sk-...
+```
+
+Resolution order: `OPENAI_API_KEY` env var → saved key → (hosted proxy, if you're on the cloud tier) → heuristic-only. Check what's active anytime:
+
+```bash
+argus key show           # masked key + where it came from
+argus doctor             # reports BYOK / hosted / heuristic-only mode
+```
+
+No key? ARGUS still works — it falls back to heuristic-only detection, no crashes.
+
 ## Getting Started (AI-Powered Setup)
 
 The fastest way to set up ARGUS — let your AI assistant handle the integration:
@@ -32,13 +55,13 @@ The fastest way to set up ARGUS — let your AI assistant handle the integration
 
 **3. Copy the prompt and paste it into your AI assistant** (Claude, ChatGPT, Cursor, etc.) — it will handle the full setup for you. This is the **most important step**.
 
-**4. Log in to ARGUS**
+**4. (Optional) Log in for hosted cloud sync**
 
 ```bash
 argus login
 ```
 
-Sign in with your Google account to enable cloud sync and the dashboard.
+Signing in with Google enables **hosted** cloud sync and the shared trends registry — part of the managed/enterprise tier. It is **entirely optional**: the open-source package is fully local and needs no login. (`argus login` reports "hosted-only feature" unless a hosted backend is configured.)
 
 **5. Open the dashboard**
 
@@ -134,7 +157,7 @@ For subtle quality issues that pattern matching can't catch:
 watcher = ArgusWatcher(graph, semantic_judge=True)  # enabled by default
 ```
 
-LLM evaluates output quality on every node. Catches wrong tone, unhelpful responses, outdated info. Requires `OPENAI_API_KEY`.
+LLM evaluates output quality on every node. Catches wrong tone, unhelpful responses, outdated info. Requires an OpenAI key — set via `argus key set` or `OPENAI_API_KEY` (see [BYOK](#bring-your-own-key-byok)).
 
 The judge receives **all prior evidence** — validator failures, anomaly signals, inspection results — so it rules with full context, not just input/output. Every decision includes an audit trail:
 
@@ -196,8 +219,11 @@ argus replay <id> <node>             # re-run from a node
 argus diff <id-a> <id-b>             # compare two runs
 argus stats                          # signature hit stats, disable/enable/dispute signatures
 argus ui                             # web dashboard
-argus doctor                         # check setup health
-argus login                          # sign in for cloud sync
+argus doctor                         # check setup health + LLM mode (BYOK/hosted/heuristic)
+argus key set                        # save your OpenAI key locally (BYOK)
+argus key show                       # show the active key (masked) and its source
+argus key clear                      # remove the saved key
+argus login                          # (optional) sign in for hosted cloud sync
 argus logout                         # clear stored credentials
 argus whoami                         # show current login status
 argus update                         # check for newer release
@@ -245,7 +271,7 @@ Works with any framework — Prefect, Temporal, plain Python.
 
 - Python 3.9+
 - LangGraph 0.2+ (only for `ArgusWatcher`)
-- `OPENAI_API_KEY` in env for semantic features (optional — all heuristic detection works without it)
+- An OpenAI key for semantic features — set via `argus key set` or `OPENAI_API_KEY` (optional; all heuristic detection works without it)
 
 For AI setup prompts and integration guides, visit **[arguslabs.in](https://arguslabs.in)**.
 

--- a/cloud/LICENSE
+++ b/cloud/LICENSE
@@ -1,0 +1,52 @@
+Copyright (c) 2026 Varad Durge
+
+All rights reserved.
+
+Permission is hereby granted to any person obtaining a copy of this software
+and associated documentation files (the "Software") to use, copy, and modify
+the Software for non-commercial purposes only, subject to the following
+conditions:
+
+1. Attribution Requirement
+   Any use, distribution, or modification of the Software must include proper
+   attribution to the original author, Varad Durge, including this copyright
+   notice in all copies or substantial portions of the Software.
+
+2. Non-Commercial Use Only
+   The Software may not be used, in whole or in part, for commercial purposes
+   without prior written permission from the author. Commercial purposes
+   include, but are not limited to, incorporating the Software into a product
+   or service that is sold, licensed for a fee, or used to generate revenue.
+
+3. No Redistribution Without Permission
+   Redistribution of the Software, with or without modification, whether for
+   commercial or non-commercial purposes, is strictly prohibited without
+   prior written permission from the author. This includes, but is not
+   limited to, selling, sublicensing, giving away, bundling, publishing
+   forks, or making the Software (or any derivative work) available to
+   third parties through any channel.
+
+   For clarity: forking the repository for personal, private use is
+   permitted. Publishing or distributing that fork — even for free — is not.
+
+4. Derivative Works
+   Any derivative work based on the Software is subject to the same
+   restrictions as the original Software. Derivative works may not be
+   distributed, published, or made available to third parties without
+   prior written permission from the author.
+
+5. Commercial Licensing
+   Any commercial use or redistribution of the Software requires a
+   separate paid license or explicit written permission from the author.
+   Contact: varaddurge@gmail.com
+
+6. No Warranty
+   The Software is provided "as is", without warranty of any kind, express or
+   implied, including but not limited to the warranties of merchantability,
+   fitness for a particular purpose, and noninfringement.
+
+7. Limitation of Liability
+   In no event shall the author be liable for any claim, damages, or other
+   liability, whether in an action of contract, tort, or otherwise, arising
+   from, out of, or in connection with the Software or the use of or other
+   dealings in the Software.

--- a/cloud/README.md
+++ b/cloud/README.md
@@ -1,0 +1,76 @@
+# ARGUS — `cloud/` (Hosted / Enterprise Layer)
+
+> **Proprietary. Not open source.** This directory is **not** covered by the
+> Apache-2.0 license that applies to `src/argus/`. See [`LICENSE`](./LICENSE) —
+> all rights reserved; commercial use requires a separate agreement.
+> It is **excluded from the PyPI package** (`argus-agents`) via `pyproject.toml`,
+> so open-source `pip install` users never receive it.
+
+This is the hosted/enterprise half of ARGUS's open-core split. The open-source
+core in `src/argus/` is fully functional on its own (local storage, BYOK LLM,
+heuristic + semantic detection). This layer adds the **managed cloud tier** on
+top of that same codebase — no fork, no separate branch, just an import boundary.
+
+## What this layer enables
+
+Everything here is gated behind configuration; when it is absent (open-source
+install), the core silently runs local-only.
+
+| Capability | Open-source core | With `cloud/` configured |
+|------------|------------------|--------------------------|
+| Run storage | local `.argus/runs/*.json` | + sync to hosted Supabase |
+| LLM calls | BYOK (user's own key) | hosted proxy (managed key, no BYOK needed) |
+| Learned trends | local `custom_signatures.json` only | + shared community/team registry |
+| Auth (`argus login`) | disabled (hosted-only feature) | Google OAuth via hosted Supabase |
+| Dashboard | local, no account | account-backed, cloud runs |
+
+## Contents
+
+| File | Role |
+|------|------|
+| `config.py` | Hosted Supabase URL + anon key (RLS-protected, public-safe) and `PROXY_URL`; `apply_env()` exports them into the environment. |
+| `LICENSE` | Proprietary license for this directory. |
+
+The actual Supabase migrations, RLS policies, and the LLM-proxy edge function
+live in the repo's top-level `supabase/` directory (also excluded from PyPI).
+The real secret — the OpenAI key used by the proxy — lives **only** in Supabase
+Edge Function secrets, never in this repo.
+
+## How activation works
+
+The core (`src/argus/cloud.py`) reads its Supabase config from two environment
+variables and no-ops when they are unset:
+
+- `ARGUS_SUPABASE_URL`
+- `ARGUS_SUPABASE_ANON_KEY`
+
+There are two ways they get set in a hosted deployment:
+
+1. **Automatic (full-repo deployment).** `src/argus/__init__.py` attempts
+   `from cloud.config import apply_env` on import and calls it. When the repo
+   root is on `PYTHONPATH` (i.e. `cloud/` is importable), the hosted config is
+   wired in automatically. In the open-source pip package `cloud/` is absent, so
+   this import fails and is silently skipped.
+
+2. **Explicit / container env.** Set `ARGUS_SUPABASE_URL` and
+   `ARGUS_SUPABASE_ANON_KEY` directly in the deployment environment
+   (Docker/systemd/Vercel/etc.). These take precedence and are the recommended
+   approach for production, since they are read before any Python import.
+
+```python
+# Hosted entrypoint (full repo on path)
+from cloud.config import apply_env
+apply_env()          # ARGUS_SUPABASE_URL / _ANON_KEY now set if not already
+import argus         # core picks up the hosted config
+```
+
+## Do not
+
+- Do **not** move code here that the open-source core needs to function — the
+  core must stay fully usable without `cloud/`.
+- Do **not** hardcode real secrets (service-role keys, OpenAI keys) here. Only
+  the public, RLS-protected anon key belongs in `config.py`.
+- Do **not** relicense this directory under Apache-2.0.
+
+See the repository [`README.md`](../README.md) for the open-source product and
+BYOK usage.

--- a/cloud/config.py
+++ b/cloud/config.py
@@ -1,0 +1,28 @@
+"""Hosted/enterprise Supabase configuration.
+
+NOT shipped in the PyPI package (excluded via pyproject.toml). The hosted
+deployment imports this and calls apply_env() at startup so that
+src/argus/cloud.py picks up the Supabase config from the environment.
+
+The anon key is RLS-protected and safe to embed; the real secret (the OpenAI
+key used by the proxy) lives only in Supabase Edge Function secrets.
+"""
+
+from __future__ import annotations
+
+import os
+
+SUPABASE_URL = "https://isnphpbckxfjsxllryrg.supabase.co"
+SUPABASE_ANON_KEY = (
+    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9."
+    "eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImlzbnBocGJja3hmanN4bGxyeXJnIiwi"
+    "cm9sZSI6ImFub24iLCJpYXQiOjE3Nzc0MDcxNjQsImV4cCI6MjA5Mjk4MzE2NH0."
+    "nfaMxbDL9E8gyvV7k2r6F8PQhAcxdZ4QVlkVWloJ88Q"
+)
+PROXY_URL = f"{SUPABASE_URL}/functions/v1/llm-proxy"
+
+
+def apply_env() -> None:
+    """Export hosted Supabase config into the environment if not already set."""
+    os.environ.setdefault("ARGUS_SUPABASE_URL", SUPABASE_URL)
+    os.environ.setdefault("ARGUS_SUPABASE_ANON_KEY", SUPABASE_ANON_KEY)

--- a/docs/superpowers/plans/2026-08-11-open-core-byok.md
+++ b/docs/superpowers/plans/2026-08-11-open-core-byok.md
@@ -1,0 +1,1016 @@
+# Open-Core Separation + BYOK Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `pip install argus-agents` a fully working BYOK product with no ARGUS infra dependency, while keeping the hosted/enterprise deployment working via env vars, all in one public repo.
+
+**Architecture:** The open-source core (`src/argus/`) resolves an OpenAI key from env or a locally-saved config file and calls OpenAI directly; if neither exists it falls back to the hosted proxy (only when Supabase env vars are configured), else to heuristic-only detection. Supabase URL/key move out of the source into env vars (real values live in the git-tracked-but-PyPI-excluded `cloud/` folder). The repo is dual-licensed: Apache-2.0 for `src/argus/`, proprietary for `cloud/`.
+
+**Tech Stack:** Python 3.9+, stdlib `urllib` (no new deps), Typer CLI, pytest, hatchling build.
+
+**Spec:** `docs/superpowers/specs/2026-08-11-open-core-byok-design.md`
+
+---
+
+## File map
+
+| File | Responsibility | Action |
+|------|----------------|--------|
+| `src/argus/user_config.py` | Load/save local BYOK OpenAI key; resolve env-or-saved key | Create |
+| `src/argus/llm_proxy.py` | BYOK-direct-or-proxy LLM calls | Modify |
+| `src/argus/embedding_store.py` | Use resolved key for OpenAI client | Modify |
+| `src/argus/cloud.py` | Supabase URL/key from env, no-op when unset | Modify |
+| `src/argus/cli/cmd_key.py` | `argus key set/show/clear` | Create |
+| `src/argus/cli/main.py` | Register `key` command | Modify |
+| `src/argus/cli/cmd_login.py` | Hosted-only guard when Supabase unset | Modify |
+| `src/argus/cli/cmd_open_ui.py` | Guard report upload when Supabase unset | Modify |
+| `src/argus/cli/cmd_doctor.py` | Report LLM/storage mode | Modify |
+| `cloud/config.py` | Real Supabase URL/anon key/proxy + `apply_env()` | Create |
+| `cloud/LICENSE` | Proprietary license for `cloud/` | Create |
+| `LICENSE` | Apache-2.0 + pointer to `cloud/LICENSE` | Replace |
+| `pyproject.toml` | Exclude `cloud/`, set Apache-2.0 license | Modify |
+| `tests/test_smoke.py` | New tests for all above | Modify |
+
+---
+
+## Task 1: Local BYOK key store (`user_config.py`)
+
+**Files:**
+- Create: `src/argus/user_config.py`
+- Test: `tests/test_smoke.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+@pytest.mark.unit
+def test_user_config_save_load_clear(tmp_path, monkeypatch):
+    import argus.user_config as uc
+
+    monkeypatch.setattr(uc, "_CONFIG_DIR", tmp_path / ".argus")
+    monkeypatch.setattr(uc, "_CONFIG_FILE", tmp_path / ".argus" / "config.json")
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    assert uc.get_saved_openai_key() is None
+    uc.set_openai_key("sk-test-123")
+    assert uc.get_saved_openai_key() == "sk-test-123"
+    # file is chmod 600
+    import stat
+    mode = stat.S_IMODE((tmp_path / ".argus" / "config.json").stat().st_mode)
+    assert mode == 0o600
+    uc.clear_openai_key()
+    assert uc.get_saved_openai_key() is None
+
+
+@pytest.mark.unit
+def test_resolve_openai_key_prefers_env(tmp_path, monkeypatch):
+    import argus.user_config as uc
+
+    monkeypatch.setattr(uc, "_CONFIG_DIR", tmp_path / ".argus")
+    monkeypatch.setattr(uc, "_CONFIG_FILE", tmp_path / ".argus" / "config.json")
+    uc.set_openai_key("sk-saved")
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-env")
+    assert uc.resolve_openai_key() == "sk-env"
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    assert uc.resolve_openai_key() == "sk-saved"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_smoke.py::test_user_config_save_load_clear -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'argus.user_config'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `src/argus/user_config.py`:
+
+```python
+"""Local user config for BYOK (bring-your-own-key).
+
+Stores the user's OpenAI API key at ~/.argus/config.json (chmod 600) so it
+persists across sessions. The environment variable OPENAI_API_KEY always wins
+over the saved key (12-factor override).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+_CONFIG_DIR = Path.home() / ".argus"
+_CONFIG_FILE = _CONFIG_DIR / "config.json"
+
+
+def _read() -> dict:
+    if not _CONFIG_FILE.exists():
+        return {}
+    try:
+        return json.loads(_CONFIG_FILE.read_text(encoding="utf-8"))
+    except Exception:
+        return {}
+
+
+def _write(data: dict) -> None:
+    _CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+    _CONFIG_FILE.write_text(json.dumps(data, indent=2), encoding="utf-8")
+    _CONFIG_FILE.chmod(0o600)
+
+
+def get_saved_openai_key() -> str | None:
+    """Return the OpenAI key saved on disk, or None."""
+    key = _read().get("openai_api_key")
+    return key or None
+
+
+def set_openai_key(key: str) -> None:
+    """Persist the OpenAI key to ~/.argus/config.json (chmod 600)."""
+    data = _read()
+    data["openai_api_key"] = key.strip()
+    _write(data)
+
+
+def clear_openai_key() -> None:
+    """Remove the saved OpenAI key."""
+    data = _read()
+    data.pop("openai_api_key", None)
+    _write(data)
+
+
+def resolve_openai_key() -> str | None:
+    """Resolve the OpenAI key: env OPENAI_API_KEY first, then saved key."""
+    env = os.environ.get("OPENAI_API_KEY")
+    if env:
+        return env
+    return get_saved_openai_key()
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest tests/test_smoke.py::test_user_config_save_load_clear tests/test_smoke.py::test_resolve_openai_key_prefers_env -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/argus/user_config.py tests/test_smoke.py
+git commit -m "feat: add local BYOK openai key store (user_config)"
+```
+
+---
+
+## Task 2: BYOK path in `llm_proxy.py`
+
+**Files:**
+- Modify: `src/argus/llm_proxy.py`
+- Test: `tests/test_smoke.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+@pytest.mark.unit
+def test_llm_proxy_uses_byok_when_key_present(monkeypatch):
+    import argus.llm_proxy as lp
+
+    captured = {}
+
+    def fake_direct(*, api_key, model, messages, max_tokens, temperature,
+                    response_format, timeout):
+        captured["api_key"] = api_key
+        captured["model"] = model
+        return {"choices": [{"message": {"content": "ok"}}]}
+
+    monkeypatch.setattr(lp, "_call_openai_direct", fake_direct)
+    monkeypatch.setattr(lp, "resolve_openai_key", lambda: "sk-byok")
+
+    out = lp.create_chat_completion(model="gpt-4o-mini", messages=[{"role": "user", "content": "hi"}])
+    assert "error" not in out
+    assert captured["api_key"] == "sk-byok"
+    assert captured["model"] == "gpt-4o-mini"
+
+
+@pytest.mark.unit
+def test_llm_proxy_errors_when_no_key_and_no_proxy(monkeypatch):
+    import argus.llm_proxy as lp
+
+    monkeypatch.setattr(lp, "resolve_openai_key", lambda: None)
+    monkeypatch.setattr(lp, "SUPABASE_URL", None)
+
+    out = lp.create_chat_completion(model="gpt-4o-mini", messages=[{"role": "user", "content": "hi"}])
+    assert "error" in out
+
+
+@pytest.mark.unit
+def test_llm_proxy_is_available_true_with_byok(monkeypatch):
+    import argus.llm_proxy as lp
+
+    monkeypatch.setattr(lp, "resolve_openai_key", lambda: "sk-byok")
+    assert lp.is_available() is True
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_smoke.py::test_llm_proxy_uses_byok_when_key_present -v`
+Expected: FAIL with `AttributeError: ... has no attribute '_call_openai_direct'`
+
+- [ ] **Step 3: Write implementation — replace `src/argus/llm_proxy.py` entirely**
+
+```python
+"""LLM calls with BYOK-first resolution.
+
+Priority:
+  1. OPENAI_API_KEY env var         -> call OpenAI directly (BYOK)
+  2. saved key (~/.argus/config)    -> call OpenAI directly (BYOK)
+  3. logged in + Supabase configured -> route through the ARGUS proxy
+  4. none of the above              -> {"error": ...}; callers fall back to
+                                       heuristic-only detection.
+
+Exposes create_chat_completion() mirroring the OpenAI chat completions shape.
+Uses only stdlib urllib — no new dependency.
+"""
+
+from __future__ import annotations
+
+import json
+import urllib.error
+import urllib.request
+from typing import Any
+
+from argus.cloud import SUPABASE_URL, _get_valid_credentials
+from argus.user_config import resolve_openai_key
+
+_PROXY_URL = f"{SUPABASE_URL}/functions/v1/llm-proxy" if SUPABASE_URL else None
+_OPENAI_URL = "https://api.openai.com/v1/chat/completions"
+
+
+def _call_openai_direct(
+    *,
+    api_key: str,
+    model: str,
+    messages: list[dict[str, str]],
+    max_tokens: int = 2000,
+    temperature: float = 0.3,
+    response_format: dict[str, str] | None = None,
+    timeout: float = 30.0,
+) -> dict[str, Any]:
+    """Call OpenAI's chat completions endpoint directly with the user's key."""
+    payload: dict[str, Any] = {
+        "model": model,
+        "messages": messages,
+        "max_tokens": max_tokens,
+        "temperature": temperature,
+    }
+    if response_format:
+        payload["response_format"] = response_format
+
+    req = urllib.request.Request(
+        _OPENAI_URL,
+        data=json.dumps(payload).encode(),
+        headers={
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {api_key}",
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return json.loads(resp.read())
+    except urllib.error.HTTPError as exc:
+        try:
+            body = json.loads(exc.read())
+            msg = body.get("error", {})
+            msg = msg.get("message") if isinstance(msg, dict) else msg
+            return {"error": msg or f"OpenAI HTTP {exc.code}"}
+        except Exception:
+            return {"error": f"OpenAI HTTP {exc.code}"}
+    except Exception as exc:
+        return {"error": f"OpenAI error: {exc}"}
+
+
+def _call_proxy(
+    *,
+    model: str,
+    messages: list[dict[str, str]],
+    max_tokens: int = 2000,
+    temperature: float = 0.3,
+    response_format: dict[str, str] | None = None,
+    timeout: float = 30.0,
+) -> dict[str, Any]:
+    """Call the ARGUS LLM proxy edge function (hosted deployments only)."""
+    if not SUPABASE_URL or _PROXY_URL is None:
+        return {"error": "No LLM configured. Set OPENAI_API_KEY or run: argus key set"}
+
+    creds = _get_valid_credentials()
+    if creds is None:
+        return {"error": "No LLM configured. Set OPENAI_API_KEY or run: argus key set"}
+
+    payload: dict[str, Any] = {
+        "model": model,
+        "messages": messages,
+        "max_tokens": max_tokens,
+        "temperature": temperature,
+    }
+    if response_format:
+        payload["response_format"] = response_format
+
+    req = urllib.request.Request(
+        _PROXY_URL,
+        data=json.dumps(payload).encode(),
+        headers={
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {creds.access_token}",
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return json.loads(resp.read())
+    except urllib.error.HTTPError as exc:
+        try:
+            body = json.loads(exc.read())
+            return {"error": body.get("error", f"Proxy HTTP {exc.code}")}
+        except Exception:
+            return {"error": f"Proxy HTTP {exc.code}"}
+    except Exception as exc:
+        return {"error": f"Proxy error: {exc}"}
+
+
+def create_chat_completion(
+    *,
+    model: str,
+    messages: list[dict[str, str]],
+    max_tokens: int = 2000,
+    temperature: float = 0.3,
+    response_format: dict[str, str] | None = None,
+    api_key: str | None = None,
+    timeout: float = 30.0,
+) -> dict[str, Any]:
+    """Create a chat completion via BYOK direct call, else the hosted proxy.
+
+    Returns the raw OpenAI response dict on success, or {"error": "..."} on
+    failure. Callers should check for the "error" key.
+    """
+    key = api_key or resolve_openai_key()
+    if key:
+        return _call_openai_direct(
+            api_key=key,
+            model=model,
+            messages=messages,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            response_format=response_format,
+            timeout=timeout,
+        )
+    return _call_proxy(
+        model=model,
+        messages=messages,
+        max_tokens=max_tokens,
+        temperature=temperature,
+        response_format=response_format,
+        timeout=timeout,
+    )
+
+
+def is_available() -> bool:
+    """True if any LLM path is usable: BYOK key, or logged-in hosted proxy."""
+    if resolve_openai_key():
+        return True
+    if not SUPABASE_URL:
+        return False
+    return _get_valid_credentials() is not None
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest tests/test_smoke.py -k "llm_proxy" -v`
+Expected: PASS (3 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/argus/llm_proxy.py tests/test_smoke.py
+git commit -m "feat: BYOK-first LLM resolution in llm_proxy"
+```
+
+---
+
+## Task 3: Supabase config from env in `cloud.py`
+
+**Files:**
+- Modify: `src/argus/cloud.py:17-24` (constants), `is_logged_in`, `_get_valid_credentials`
+- Test: `tests/test_smoke.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+@pytest.mark.unit
+def test_cloud_no_hardcoded_supabase_url():
+    import inspect
+    import argus.cloud as cloud
+    src = inspect.getsource(cloud)
+    assert "isnphpbckxfjsxllryrg" not in src  # real project ref must be gone
+
+
+@pytest.mark.unit
+def test_cloud_noops_when_unconfigured(monkeypatch):
+    import argus.cloud as cloud
+    monkeypatch.setattr(cloud, "SUPABASE_URL", None)
+    monkeypatch.setattr(cloud, "SUPABASE_ANON_KEY", None)
+    assert cloud.is_logged_in() is False
+    assert cloud.push_run({"run_id": "x"}) is False
+    assert cloud.pull_shared_signatures() == []
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_smoke.py::test_cloud_no_hardcoded_supabase_url -v`
+Expected: FAIL (URL still hardcoded)
+
+- [ ] **Step 3: Edit `src/argus/cloud.py`**
+
+Replace lines 17-24 (the hardcoded constants block):
+
+```python
+# ── Supabase config (hosted deployments set these via cloud/config.py) ────
+import os  # noqa: E402
+
+SUPABASE_URL = os.environ.get("ARGUS_SUPABASE_URL")
+SUPABASE_ANON_KEY = os.environ.get("ARGUS_SUPABASE_ANON_KEY")
+```
+
+Replace `is_logged_in` (currently lines 75-77):
+
+```python
+def is_logged_in() -> bool:
+    if SUPABASE_URL is None:
+        return False
+    creds = load_credentials()
+    return creds is not None
+```
+
+Add a guard at the top of `_get_valid_credentials` (currently lines 115-119):
+
+```python
+def _get_valid_credentials() -> Credentials | None:
+    if SUPABASE_URL is None:
+        return None
+    creds = load_credentials()
+    if creds is None:
+        return None
+    return _refresh_if_needed(creds)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest tests/test_smoke.py -k "cloud" -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/argus/cloud.py tests/test_smoke.py
+git commit -m "refactor: read Supabase config from env, no-op when unset"
+```
+
+---
+
+## Task 4: Guard hosted-only CLI paths (`cmd_login.py`, `cmd_open_ui.py`)
+
+**Files:**
+- Modify: `src/argus/cli/cmd_login.py` (`login` function, ~line 80)
+- Modify: `src/argus/cli/cmd_open_ui.py:1127-1156` (report upload block)
+- Test: `tests/test_smoke.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+@pytest.mark.unit
+def test_login_reports_hosted_only_when_unconfigured(monkeypatch, capsys):
+    import argus.cli.cmd_login as cl
+    monkeypatch.setattr(cl, "SUPABASE_URL", None)
+    cl.login()
+    out = capsys.readouterr().out.lower()
+    assert "hosted" in out or "not available" in out
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_smoke.py::test_login_reports_hosted_only_when_unconfigured -v`
+Expected: FAIL (login tries to open browser / build auth URL against None)
+
+- [ ] **Step 3: Edit `login()` in `src/argus/cli/cmd_login.py`**
+
+Add at the very top of the `login()` function body (before the existing `if is_logged_in():` check around line 82):
+
+```python
+    if SUPABASE_URL is None:
+        _console.print(
+            "  [yellow]Cloud login is a hosted-only feature.[/yellow]\n"
+            "  ARGUS runs fully local with your own key — set one with: "
+            "[bold]argus key set[/bold]\n"
+            "  or export OPENAI_API_KEY."
+        )
+        return
+```
+
+- [ ] **Step 4: Edit `cmd_open_ui.py` report-upload block (lines ~1127-1156)**
+
+Wrap the block that imports and uses `SUPABASE_URL`/`SUPABASE_ANON_KEY` so it is skipped when unset. Immediately before the existing `from argus.cloud import (SUPABASE_ANON_KEY, SUPABASE_URL)` import at line ~1127, add:
+
+```python
+                from argus.cloud import SUPABASE_URL as _sb_url
+
+                if _sb_url is None:
+                    return  # local-only mode: report upload is hosted-only
+```
+
+(Keep the existing block below it unchanged; it only runs when a URL is configured.)
+
+- [ ] **Step 5: Run tests + commit**
+
+Run: `pytest tests/test_smoke.py -k "login" -v`
+Expected: PASS
+
+```bash
+git add src/argus/cli/cmd_login.py src/argus/cli/cmd_open_ui.py tests/test_smoke.py
+git commit -m "fix: guard hosted-only CLI paths when Supabase unconfigured"
+```
+
+---
+
+## Task 5: `argus key` command (`cmd_key.py` + register)
+
+**Files:**
+- Create: `src/argus/cli/cmd_key.py`
+- Modify: `src/argus/cli/main.py` (import + command registration)
+- Test: `tests/test_smoke.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+@pytest.mark.unit
+def test_cmd_key_set_show_clear(tmp_path, monkeypatch, capsys):
+    import argus.user_config as uc
+    import argus.cli.cmd_key as ck
+
+    monkeypatch.setattr(uc, "_CONFIG_DIR", tmp_path / ".argus")
+    monkeypatch.setattr(uc, "_CONFIG_FILE", tmp_path / ".argus" / "config.json")
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    ck.key_set("sk-abcdef123456")
+    assert uc.get_saved_openai_key() == "sk-abcdef123456"
+
+    ck.key_show()
+    out = capsys.readouterr().out
+    assert "sk-abcdef123456" not in out  # masked
+    assert "3456" in out  # last 4 shown
+
+    ck.key_clear()
+    assert uc.get_saved_openai_key() is None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_smoke.py::test_cmd_key_set_show_clear -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'argus.cli.cmd_key'`
+
+- [ ] **Step 3: Create `src/argus/cli/cmd_key.py`**
+
+```python
+"""argus key — manage the local BYOK OpenAI API key."""
+
+from __future__ import annotations
+
+from rich.console import Console
+
+from argus import user_config
+
+_console = Console()
+
+
+def _mask(key: str) -> str:
+    if len(key) <= 8:
+        return "•" * len(key)
+    return f"{key[:3]}…{key[-4:]}"
+
+
+def key_set(value: str | None = None) -> None:
+    """Save an OpenAI key locally (prompts if not passed)."""
+    if not value:
+        import getpass
+
+        value = getpass.getpass("OpenAI API key (input hidden): ").strip()
+    if not value:
+        _console.print("  [red]No key entered.[/red]")
+        return
+    user_config.set_openai_key(value)
+    _console.print(f"  [green]Saved[/green] key {_mask(value)} to ~/.argus/config.json")
+
+
+def key_show() -> None:
+    """Show the currently resolved key (masked) and its source."""
+    import os
+
+    env = os.environ.get("OPENAI_API_KEY")
+    saved = user_config.get_saved_openai_key()
+    if env:
+        _console.print(f"  key: {_mask(env)}  [dim](source: OPENAI_API_KEY env)[/dim]")
+    elif saved:
+        _console.print(f"  key: {_mask(saved)}  [dim](source: ~/.argus/config.json)[/dim]")
+    else:
+        _console.print(
+            "  [yellow]No OpenAI key set.[/yellow] Run [bold]argus key set[/bold] "
+            "or export OPENAI_API_KEY."
+        )
+
+
+def key_clear() -> None:
+    """Remove the saved local key."""
+    user_config.clear_openai_key()
+    _console.print("  [green]Cleared[/green] saved key from ~/.argus/config.json")
+```
+
+- [ ] **Step 4: Register in `src/argus/cli/main.py`**
+
+Add import after line 21 (`from argus.cli.cmd_login import ...`):
+
+```python
+from argus.cli.cmd_key import key_clear, key_set, key_show
+```
+
+Add a Typer sub-app registration after line 37 (`app.add_typer(open_app, name="open")`):
+
+```python
+key_app = typer.Typer(help="Manage your BYOK OpenAI API key.", no_args_is_help=True)
+app.add_typer(key_app, name="key")
+
+
+@key_app.command("set")
+def cmd_key_set(
+    value: Annotated[
+        Optional[str],
+        typer.Argument(help="OpenAI API key. Omit to be prompted with hidden input."),
+    ] = None,
+) -> None:
+    """Save your OpenAI API key locally (~/.argus/config.json)."""
+    key_set(value)
+
+
+@key_app.command("show")
+def cmd_key_show() -> None:
+    """Show the currently resolved key (masked) and its source."""
+    key_show()
+
+
+@key_app.command("clear")
+def cmd_key_clear() -> None:
+    """Remove the saved local key."""
+    key_clear()
+```
+
+Also add to the `_COMMANDS` help list (after the `"whoami"` entry, line ~70):
+
+```python
+    ("key set", "save your OpenAI API key locally for BYOK mode"),
+```
+
+- [ ] **Step 5: Run tests + smoke-check CLI wiring**
+
+Run: `pytest tests/test_smoke.py::test_cmd_key_set_show_clear -v`
+Expected: PASS
+
+Run: `argus key --help`
+Expected: shows `set`, `show`, `clear` subcommands
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/argus/cli/cmd_key.py src/argus/cli/main.py tests/test_smoke.py
+git commit -m "feat: add 'argus key' command for local BYOK key management"
+```
+
+---
+
+## Task 6: `embedding_store` uses resolved key
+
+**Files:**
+- Modify: `src/argus/embedding_store.py:30-47` (`_get_client`)
+- Test: `tests/test_smoke.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+@pytest.mark.unit
+def test_embedding_client_uses_resolved_key(monkeypatch):
+    import argus.embedding_store as es
+
+    captured = {}
+
+    class FakeOpenAI:
+        def __init__(self, api_key=None):
+            captured["api_key"] = api_key
+
+    monkeypatch.setattr(es, "_client", None)
+    monkeypatch.setattr("argus.user_config.resolve_openai_key", lambda: "sk-embed")
+    import sys, types
+    fake_mod = types.ModuleType("openai")
+    fake_mod.OpenAI = FakeOpenAI
+    monkeypatch.setitem(sys.modules, "openai", fake_mod)
+
+    es._get_client()
+    assert captured["api_key"] == "sk-embed"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_smoke.py::test_embedding_client_uses_resolved_key -v`
+Expected: FAIL (client built with `OpenAI()` — no api_key passed)
+
+- [ ] **Step 3: Edit `_get_client` in `src/argus/embedding_store.py`**
+
+Replace the body after the dotenv block (the `from openai import OpenAI` / `_client = OpenAI()` lines, ~44-47) with:
+
+```python
+        from openai import OpenAI  # noqa: PLC0415
+
+        from argus.user_config import resolve_openai_key  # noqa: PLC0415
+
+        key = resolve_openai_key()
+        _client = OpenAI(api_key=key) if key else OpenAI()
+        return _client
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/test_smoke.py::test_embedding_client_uses_resolved_key -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/argus/embedding_store.py tests/test_smoke.py
+git commit -m "feat: embedding_store uses BYOK-resolved OpenAI key"
+```
+
+---
+
+## Task 7: `doctor` reports LLM + storage mode
+
+**Files:**
+- Modify: `src/argus/cli/cmd_doctor.py` (add `_check_llm_mode`, register in `checks`)
+- Test: `tests/test_smoke.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+@pytest.mark.unit
+def test_doctor_llm_mode_byok(monkeypatch):
+    import argus.cli.cmd_doctor as d
+    monkeypatch.setattr("argus.user_config.resolve_openai_key", lambda: "sk-x")
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-x")
+    ok, msg = d._check_llm_mode()
+    assert ok is True
+    assert "BYOK" in msg
+
+
+@pytest.mark.unit
+def test_doctor_llm_mode_heuristic(monkeypatch):
+    import argus.cli.cmd_doctor as d
+    monkeypatch.setattr("argus.user_config.resolve_openai_key", lambda: None)
+    monkeypatch.setattr("argus.cloud.SUPABASE_URL", None)
+    ok, msg = d._check_llm_mode()
+    assert "heuristic" in msg.lower()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_smoke.py::test_doctor_llm_mode_byok -v`
+Expected: FAIL with `AttributeError: ... no attribute '_check_llm_mode'`
+
+- [ ] **Step 3: Add `_check_llm_mode` to `src/argus/cli/cmd_doctor.py`**
+
+Insert before `def doctor()` (line ~183):
+
+```python
+def _check_llm_mode() -> tuple[bool, str]:
+    """Report which LLM path is active: BYOK / hosted / heuristic-only."""
+    import os
+
+    from argus.cloud import SUPABASE_URL
+    from argus.user_config import resolve_openai_key
+
+    if resolve_openai_key():
+        source = "env" if os.environ.get("OPENAI_API_KEY") else "saved"
+        return True, f"BYOK ({source}) — calling OpenAI directly"
+    if SUPABASE_URL is not None:
+        from argus.cloud import is_logged_in
+
+        if is_logged_in():
+            return True, "hosted proxy (logged in)"
+        return True, "hosted available — run: argus login (or set OPENAI_API_KEY)"
+    return True, "heuristic-only — no key set (argus key set to enable LLM checks)"
+```
+
+Register it in the `checks` list inside `doctor()` (after the `("storage", _check_storage)` entry):
+
+```python
+        ("llm", _check_llm_mode),
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest tests/test_smoke.py -k "doctor_llm_mode" -v`
+Expected: PASS (2 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/argus/cli/cmd_doctor.py tests/test_smoke.py
+git commit -m "feat: argus doctor reports BYOK/hosted/heuristic LLM mode"
+```
+
+---
+
+## Task 8: Create `cloud/` folder (config + license)
+
+**Files:**
+- Create: `cloud/config.py`
+- Create: `cloud/LICENSE`
+- Create: `cloud/__init__.py` (empty)
+
+- [ ] **Step 1: Create `cloud/config.py`**
+
+```python
+"""Hosted/enterprise Supabase configuration.
+
+NOT shipped in the PyPI package (excluded via pyproject.toml). The hosted
+deployment imports this and calls apply_env() at startup so that
+src/argus/cloud.py picks up the Supabase config from the environment.
+
+The anon key is RLS-protected and safe to embed; the real secret (the OpenAI
+key used by the proxy) lives only in Supabase Edge Function secrets.
+"""
+
+from __future__ import annotations
+
+import os
+
+SUPABASE_URL = "https://isnphpbckxfjsxllryrg.supabase.co"
+SUPABASE_ANON_KEY = (
+    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9."
+    "eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImlzbnBocGJja3hmanN4bGxyeXJnIiwi"
+    "cm9sZSI6ImFub24iLCJpYXQiOjE3Nzc0MDcxNjQsImV4cCI6MjA5Mjk4MzE2NH0."
+    "nfaMxbDL9E8gyvV7k2r6F8PQhAcxdZ4QVlkVWloJ88Q"
+)
+PROXY_URL = f"{SUPABASE_URL}/functions/v1/llm-proxy"
+
+
+def apply_env() -> None:
+    """Export hosted Supabase config into the environment if not already set."""
+    os.environ.setdefault("ARGUS_SUPABASE_URL", SUPABASE_URL)
+    os.environ.setdefault("ARGUS_SUPABASE_ANON_KEY", SUPABASE_ANON_KEY)
+```
+
+- [ ] **Step 2: Create `cloud/__init__.py`** (empty file)
+
+```bash
+touch cloud/__init__.py
+```
+
+- [ ] **Step 3: Create `cloud/LICENSE`** — copy the current proprietary LICENSE text
+
+```bash
+cp LICENSE cloud/LICENSE
+```
+
+(The root `LICENSE` becomes Apache-2.0 in Task 9; `cloud/LICENSE` retains the proprietary terms.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add cloud/config.py cloud/__init__.py cloud/LICENSE
+git commit -m "feat: add cloud/ hosted config + proprietary license"
+```
+
+---
+
+## Task 9: Dual-license + build exclusion (`LICENSE`, `pyproject.toml`)
+
+**Files:**
+- Replace: `LICENSE` (Apache-2.0 + note)
+- Modify: `pyproject.toml` (license field, classifier, sdist exclude)
+
+- [ ] **Step 1: Replace root `LICENSE` with Apache-2.0**
+
+Write the full Apache License 2.0 text (from https://www.apache.org/licenses/LICENSE-2.0.txt) into `LICENSE`, prefixed with this note as the first lines:
+
+```
+ARGUS is open-core. The open-source core in src/argus/ is licensed under the
+Apache License, Version 2.0 (below). The cloud/ directory (hosted/enterprise
+components) is proprietary and licensed separately — see cloud/LICENSE.
+
+Copyright (c) 2026 Varad Durge
+
+--------------------------------------------------------------------------------
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+... (full Apache 2.0 body) ...
+```
+
+- [ ] **Step 2: Edit `pyproject.toml`**
+
+Change the license line (line 6):
+
+```toml
+license = "Apache-2.0"
+```
+
+Change the license classifier (in `classifiers`, replace `"License :: Other/Proprietary License",`):
+
+```toml
+    "License :: OSI Approved :: Apache Software License",
+```
+
+Add `"cloud"` to the sdist exclude list (line ~65):
+
+```toml
+exclude = ["website", "assets", "fixtures", "supabase", "cloud", "scripts", ".github"]
+```
+
+- [ ] **Step 3: Verify the build excludes `cloud/`**
+
+Run:
+```bash
+python -m build --sdist 2>/dev/null || pip install build && python -m build --sdist
+tar -tzf dist/argus_agents-*.tar.gz | grep -c "cloud/" || echo "cloud/ excluded: OK"
+```
+Expected: `cloud/ excluded: OK` (grep finds 0 → prints the OK message)
+
+Also confirm the wheel excludes it:
+```bash
+python -m build --wheel
+unzip -l dist/argus_agents-*.whl | grep -c "cloud/" || echo "wheel cloud/ excluded: OK"
+```
+Expected: `wheel cloud/ excluded: OK`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add LICENSE pyproject.toml
+git commit -m "chore: dual-license (Apache-2.0 core, proprietary cloud) + exclude cloud from build"
+```
+
+---
+
+## Task 10: End-to-end verification + full test suite
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Full test suite**
+
+Run: `pytest tests/ -q`
+Expected: all tests pass (367 existing + new).
+
+- [ ] **Step 2: Lint + type check**
+
+Run: `ruff check src/ && mypy src/argus`
+Expected: no errors.
+
+- [ ] **Step 3: Confirm zero Supabase URL references in the core**
+
+Run: `rg "isnphpbckxfjsxllryrg" src/argus/ && echo "LEAK" || echo "clean: no supabase url in src/argus"`
+Expected: `clean: no supabase url in src/argus`
+
+- [ ] **Step 4: Fresh-venv BYOK smoke test**
+
+```bash
+python -m venv /tmp/argus-byok && /tmp/argus-byok/bin/pip install -e ".[all]"
+/tmp/argus-byok/bin/argus key set sk-fake-for-doctor
+/tmp/argus-byok/bin/argus doctor
+```
+Expected: `doctor` shows `llm  BYOK (saved) — calling OpenAI directly`, storage healthy, no "please login" errors, no calls to ARGUS Supabase.
+
+- [ ] **Step 5: Confirm heuristic-only path (no key, no login)**
+
+```bash
+/tmp/argus-byok/bin/argus key clear
+env -u OPENAI_API_KEY /tmp/argus-byok/bin/argus doctor
+```
+Expected: `llm  heuristic-only — no key set`, all other checks pass, no crash.
+
+- [ ] **Step 6: Final commit (if any verification fixups were needed)**
+
+```bash
+git add -A
+git commit -m "test: verify BYOK open-core path end-to-end" --allow-empty
+```
+
+---
+
+## Notes for the implementer
+
+- **No new runtime dependency.** `llm_proxy.py` uses stdlib `urllib` for the direct OpenAI call, matching the existing proxy call style. `openai` stays an optional dep, used only by `embedding_store`.
+- **Callers are unchanged.** All 11 modules that call `create_chat_completion`/`is_available` already handle the `{"error": ...}` return, so heuristic fallback is automatic.
+- **`cloud/` is git-tracked but PyPI-excluded** — this is intentional open-core, not a secret. The anon key it contains is RLS-protected and public-safe.
+- **Hosted deployment** must call `cloud.config.apply_env()` (or otherwise set `ARGUS_SUPABASE_URL` / `ARGUS_SUPABASE_ANON_KEY`) before importing `argus.cloud` for proxy/sync to activate.

--- a/docs/superpowers/specs/2026-08-11-open-core-byok-design.md
+++ b/docs/superpowers/specs/2026-08-11-open-core-byok-design.md
@@ -1,0 +1,148 @@
+# ARGUS Open-Core Separation + BYOK — Design Spec
+
+**Ticket:** VAR-93
+**Date:** 2026-08-11
+**Status:** Approved for planning
+
+## Objective
+
+Split ARGUS into a free open-source core (`src/argus/`, the PyPI package) and a
+proprietary hosted/enterprise layer (`cloud/`), in the **same public repo, same
+branch**. A `pip install argus-agents` must give a fully working, bring-your-own-key
+(BYOK) product that never touches ARGUS-owned infrastructure. The hosted/enterprise
+deployment keeps working unchanged by setting environment variables.
+
+No forks. No enterprise branch. The open/enterprise boundary is a **folder**, not a
+git boundary.
+
+## Confirmed decisions
+
+1. **BYOK is OpenAI-only** for v1. `ANTHROPIC_API_KEY` support is deferred (all
+   internal LLM calls already use OpenAI-shape models).
+2. **Cloud sync is enterprise-only.** OSS users run local-only (`.argus/runs/*.json`).
+   No BYO-Supabase for OSS users; the storage env-var hooks exist but are undocumented.
+3. **No plugin/interface layer.** The core already degrades gracefully (cloud calls
+   are lazy and no-op when unauthenticated). We rely on env-var config + existing
+   no-op degradation, not `cloud/auth.py`/`cloud/sync.py` abstractions.
+4. **Local BYOK key persistence.** A CLI flow lets the user save their OpenAI key to
+   `~/.argus/config.json` (chmod 600) so it is reused across sessions without
+   re-entry.
+5. **Repo stays public** (already is). Dual-license to make open-core legally coherent.
+
+## Current state (why this is needed)
+
+- `llm_proxy.py` forces all LLM calls through the ARGUS Supabase Edge Function proxy;
+  `_has_own_key()` is hardcoded `False`. An outside user cannot run LLM features.
+- `cloud.py:18-24` hardcodes the ARGUS Supabase URL + anon key.
+- The proxy's real secret (OpenAI key) already lives in Supabase (`Deno.env`), **not**
+  in the repo — confirmed safe.
+- `LICENSE` currently reads "All rights reserved" — proprietary, which contradicts
+  open source and blocks external use/contribution.
+
+## Key resolution order (LLM)
+
+```
+1. OPENAI_API_KEY env var            → call OpenAI directly (BYOK, 12-factor override)
+2. saved key in ~/.argus/config.json → call OpenAI directly (BYOK, persisted)
+3. logged in AND hosted configured   → route through ARGUS proxy (existing behavior)
+4. none of the above                 → return {"error": ...}; callers fall back to
+                                        heuristic-only detection (no crash)
+```
+
+All 11 current callers of `create_chat_completion` already check for an `"error"` key
+and degrade, so callers are unchanged.
+
+## Architecture: after
+
+```
+ARGUS/
+├── src/argus/          ← open-source core (Apache-2.0) — the PyPI package
+│   ├── llm_proxy.py    ← BYOK path + proxy fallback
+│   ├── user_config.py  ← NEW: load/save local BYOK key (~/.argus/config.json)
+│   ├── cloud.py        ← Supabase URL/key from env, no-op when unset
+│   └── cli/cmd_key.py  ← NEW: argus key set/show/clear
+├── cloud/              ← proprietary (excluded from PyPI)
+│   ├── config.py       ← the real Supabase URL, anon key, proxy URL (public-safe)
+│   └── LICENSE         ← proprietary license
+├── supabase/           ← migrations + llm-proxy edge function (already build-excluded)
+├── website/            ← hosted dashboard + billing (proprietary)
+└── LICENSE             ← Apache-2.0 + note pointing to cloud/LICENSE
+```
+
+## Work breakdown
+
+### 1. LLM layer — BYOK (`llm_proxy.py`, `user_config.py`, `cmd_key.py`, `embedding_store.py`)
+
+- **`src/argus/user_config.py`** (new, small): `get_openai_key()` /
+  `set_openai_key(key)` / `clear_openai_key()`, reading/writing
+  `~/.argus/config.json` (chmod 600). Reuses the `~/.argus/` dir pattern already used
+  by `cloud.py` credentials.
+- **`llm_proxy.py`**: implement the 4-step resolution order above.
+  `create_chat_completion` calls OpenAI's chat completions endpoint directly when a
+  BYOK key is resolved (stdlib `urllib`, same as the proxy call — no new dependency).
+  Proxy path unchanged. `is_available()` returns True if any of: env key, saved key, or
+  logged-in+configured.
+- **`cli/cmd_key.py`** (new): `argus key set` (prompt hidden input or accept arg),
+  `argus key show` (masked), `argus key clear`. Register in `cli/main.py`.
+- **`embedding_store.py`**: resolve the OpenAI key via `user_config` (env → saved);
+  skip embedding-based dedup gracefully if no key.
+
+### 2. Secrets → env (`cloud.py`, `cmd_login.py`, `cmd_open_ui.py`, `cmd_doctor.py`)
+
+- **`cloud.py`**: `SUPABASE_URL = os.environ.get("ARGUS_SUPABASE_URL")`,
+  `SUPABASE_ANON_KEY = os.environ.get("ARGUS_SUPABASE_ANON_KEY")`, default `None`.
+  When unset, all cloud functions return their existing no-op value
+  (`is_logged_in()`→False, `push_run()`→False, `pull_shared_signatures()`→[]).
+  No hardcoded Supabase URL remains in `src/argus/`.
+- **`cmd_login.py`**: if `ARGUS_SUPABASE_URL` is unset, print a clear "cloud login is a
+  hosted-only feature" message instead of attempting/crashing.
+- **`cmd_open_ui.py`** (lines ~1127-1156): the report-upload path reads
+  `SUPABASE_URL`/`SUPABASE_ANON_KEY` directly — guard it so local-only UI works when
+  unset.
+- **`cmd_doctor.py`**: report LLM mode (`BYOK (env)` / `BYOK (saved)` / `hosted` /
+  `heuristic-only`) and storage mode (`local` / `cloud`).
+- `feedback_store.py`, `storage.py`, `registry.py`, `candidate_store.py`: already lazy
+  and no-op; verify no behavior change when unset (no edits expected beyond confirming).
+
+### 3. `cloud/` folder + build exclusion (`cloud/config.py`, `pyproject.toml`)
+
+- **`cloud/config.py`**: holds the real (public-safe) Supabase URL, anon key, and proxy
+  URL, plus an `apply_env()` helper that sets the `ARGUS_SUPABASE_URL` /
+  `ARGUS_SUPABASE_ANON_KEY` env vars if not already set. The hosted deployment imports
+  and calls this at startup. OSS installs never ship `cloud/`, so it is never imported.
+- `supabase/` stays where it is (already excluded from sdist; contains the proxy edge
+  function and migrations).
+- **`pyproject.toml`**: add `"cloud"` to the `[tool.hatch.build.targets.sdist]` exclude
+  list. The wheel already only packages `src/argus`, so `cloud/` is already
+  wheel-excluded — verify.
+
+### 4. Dual licensing (`LICENSE`, `cloud/LICENSE`, `pyproject.toml`, `README`)
+
+- **Root `LICENSE`** → Apache-2.0, with a short header note: "The `cloud/` directory is
+  proprietary and licensed separately — see `cloud/LICENSE`."
+- **`cloud/LICENSE`** → proprietary ("all rights reserved; commercial use requires a
+  separate agreement").
+- **`pyproject.toml`**: set `license = "Apache-2.0"` and the appropriate classifier.
+- **`README`**: one-line licensing note.
+
+## Verification (Phase 5 acceptance)
+
+1. Fresh venv → `pip install -e .` → package installs without `cloud/`.
+2. `argus key set` saves a key; `OPENAI_API_KEY=sk-... argus doctor` and the saved-key
+   path both report BYOK working.
+3. Run a LangGraph pipeline wrapped by ARGUS → detection pipeline works via BYOK.
+4. `argus show <run-id>` and `argus ui` work from local storage only.
+5. With no key and not logged in → heuristic-only detection, no crashes, no calls to
+   ARGUS Supabase.
+6. Grep: zero references to the ARGUS Supabase URL in `src/argus/`.
+7. All 367 existing tests pass; new tests cover key resolution order, local key
+   persistence, and cloud no-op when unconfigured.
+8. Hosted deployment (full repo + `cloud/config.py apply_env()`) behaves exactly as
+   today.
+
+## Out of scope
+
+- Anthropic BYOK.
+- BYO-Supabase for OSS users.
+- Plugin/interface abstraction layer (`cloud/auth.py`, `cloud/sync.py`).
+- Any change to the detection pipeline, inspector, watcher, registry, or models.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,14 +3,13 @@ name = "argus-agents"
 version = "0.8.11"
 description = "Production readiness platform for AI agent pipelines — detects silent failures, captures full state, enables step-level replay."
 readme = "README.md"
-license = { text = "LicenseRef-Varad-NonCommercial-1.0" }
+license = "Apache-2.0"
 requires-python = ">=3.9"
 authors = [{ name = "Varad Durge", email = "varaddurge@gmail.com" }]
 keywords = ["langgraph", "multiagent", "monitoring", "observability", "debugging", "silent-failures"]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
-    "License :: Other/Proprietary License",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
@@ -62,7 +61,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.sdist]
-exclude = ["website", "assets", "fixtures", "supabase", "scripts", ".github"]
+exclude = ["website", "assets", "fixtures", "supabase", "cloud", "scripts", ".github"]
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/argus"]

--- a/src/argus/__init__.py
+++ b/src/argus/__init__.py
@@ -32,6 +32,17 @@ Framework-agnostic usage (Prefect, Temporal, raw Python, etc.):
 
 __version__ = "0.8.11"
 
+# Hosted/enterprise activation: when the proprietary `cloud/` package is present
+# (full-repo deployment), wire its Supabase config into the environment before
+# any submodule reads it. The open-source pip package does not ship `cloud/`, so
+# this import fails and silently no-ops — BYOK users stay fully local.
+try:  # pragma: no cover - exercised only in hosted deployments
+    from cloud.config import apply_env as _apply_cloud_env
+
+    _apply_cloud_env()
+except Exception:
+    pass
+
 from argus.models import ArgusConfig, LLMInvestigationConfig
 from argus.session import ArgusSession
 from argus.watcher import ArgusWatcher

--- a/src/argus/candidate_store.py
+++ b/src/argus/candidate_store.py
@@ -204,7 +204,16 @@ def approve_candidate_shared(candidate_id: str) -> dict[str, Any] | None:
 
     Returns the signature dict on success, or None if the candidate was
     not found or the push failed.
+
+    In open-source / local-only mode (no ARGUS_SUPABASE_URL configured) there
+    is no shared community registry, so this transparently falls back to a
+    local approval — every trend stays on the user's machine.
     """
+    from argus.cloud import SUPABASE_URL  # noqa: PLC0415
+
+    if SUPABASE_URL is None:
+        return approve_candidate(candidate_id)
+
     data = load_candidates()
     cand = None
     for i, c in enumerate(data["candidates"]):

--- a/src/argus/cli/cmd_doctor.py
+++ b/src/argus/cli/cmd_doctor.py
@@ -180,6 +180,25 @@ def _check_optional_deps() -> tuple[bool, str]:
     return True, ", ".join(parts)
 
 
+def _check_llm_mode() -> tuple[bool, str]:
+    """Report which LLM path is active: BYOK / hosted / heuristic-only."""
+    import os
+
+    from argus.cloud import SUPABASE_URL
+    from argus.user_config import resolve_openai_key
+
+    if resolve_openai_key():
+        source = "env" if os.environ.get("OPENAI_API_KEY") else "saved"
+        return True, f"BYOK ({source}) — calling OpenAI directly"
+    if SUPABASE_URL is not None:
+        from argus.cloud import is_logged_in
+
+        if is_logged_in():
+            return True, "hosted proxy (logged in)"
+        return True, "hosted available — run: argus login (or set OPENAI_API_KEY)"
+    return True, "heuristic-only — no key set (argus key set to enable LLM checks)"
+
+
 def doctor() -> None:
     """Run all diagnostic checks and print results."""
     console.print()
@@ -193,6 +212,7 @@ def doctor() -> None:
         ("python", _check_python_version),
         ("langgraph", _check_langgraph),
         ("storage", _check_storage),
+        ("llm", _check_llm_mode),
         ("replay", _check_replay_readiness),
         ("optional deps", _check_optional_deps),
     ]

--- a/src/argus/cli/cmd_key.py
+++ b/src/argus/cli/cmd_key.py
@@ -1,0 +1,51 @@
+"""argus key — manage the local BYOK OpenAI API key."""
+
+from __future__ import annotations
+
+from rich.console import Console
+
+from argus import user_config
+
+_console = Console()
+
+
+def _mask(key: str) -> str:
+    if len(key) <= 8:
+        return "•" * len(key)
+    return f"{key[:3]}…{key[-4:]}"
+
+
+def key_set(value: str | None = None) -> None:
+    """Save an OpenAI key locally (prompts if not passed)."""
+    if not value:
+        import getpass
+
+        value = getpass.getpass("OpenAI API key (input hidden): ").strip()
+    if not value:
+        _console.print("  [red]No key entered.[/red]")
+        return
+    user_config.set_openai_key(value)
+    _console.print(f"  [green]Saved[/green] key {_mask(value)} to ~/.argus/config.json")
+
+
+def key_show() -> None:
+    """Show the currently resolved key (masked) and its source."""
+    import os
+
+    env = os.environ.get("OPENAI_API_KEY")
+    saved = user_config.get_saved_openai_key()
+    if env:
+        _console.print(f"  key: {_mask(env)}  [dim](source: OPENAI_API_KEY env)[/dim]")
+    elif saved:
+        _console.print(f"  key: {_mask(saved)}  [dim](source: ~/.argus/config.json)[/dim]")
+    else:
+        _console.print(
+            "  [yellow]No OpenAI key set.[/yellow] Run [bold]argus key set[/bold] "
+            "or export OPENAI_API_KEY."
+        )
+
+
+def key_clear() -> None:
+    """Remove the saved local key."""
+    user_config.clear_openai_key()
+    _console.print("  [green]Cleared[/green] saved key from ~/.argus/config.json")

--- a/src/argus/cli/cmd_key.py
+++ b/src/argus/cli/cmd_key.py
@@ -26,6 +26,12 @@ def key_set(value: str | None = None) -> None:
         return
     user_config.set_openai_key(value)
     _console.print(f"  [green]Saved[/green] key {_mask(value)} to ~/.argus/config.json")
+    _console.print(
+        "  [dim]BYOK enabled — AI-powered detection now uses your key.\n"
+        "  Next: wrap your pipeline with [bold]ArgusWatcher[/bold], run it, then "
+        "[bold]argus show[/bold] / [bold]argus ui[/bold].\n"
+        "  Check status anytime with [bold]argus doctor[/bold].[/dim]"
+    )
 
 
 def key_show() -> None:

--- a/src/argus/cli/cmd_login.py
+++ b/src/argus/cli/cmd_login.py
@@ -79,6 +79,14 @@ _CALLBACK_HTML = """\
 
 def login() -> None:
     """Run the OAuth login flow."""
+    if SUPABASE_URL is None:
+        _console.print(
+            "  [yellow]Cloud login is a hosted-only feature.[/yellow]\n"
+            "  ARGUS runs fully local with your own key — set one with: "
+            "[bold]argus key set[/bold]\n"
+            "  or export OPENAI_API_KEY."
+        )
+        return
     if is_logged_in():
         creds = load_credentials()
         if creds and time.time() < creds.expires_at - 60:

--- a/src/argus/cli/cmd_open_ui.py
+++ b/src/argus/cli/cmd_open_ui.py
@@ -1124,42 +1124,47 @@ def _make_handler(
                 # Try Supabase upload (non-blocking)
                 supabase_ok = False
                 try:
-                    from argus.cloud import (  # noqa: PLC0415
-                        SUPABASE_ANON_KEY,
-                        SUPABASE_URL,
-                        _get_valid_credentials,
-                        _supabase_request,
-                    )
+                    from argus.cloud import SUPABASE_URL as _sb_url
 
-                    creds = _get_valid_credentials()
-                    if creds:
-                        report_payload["user_id"] = creds.user_id
-                        _supabase_request(
-                            creds.access_token,
-                            "reports",
-                            method="POST",
-                            body=report_payload,
-                            extra_headers={"Prefer": "return=minimal"},
-                        )
-                        supabase_ok = True
+                    if _sb_url is None:
+                        pass  # local-only mode: report upload is hosted-only
                     else:
-                        # Fallback: use anon key so reports work without login
-                        import urllib.request as _ur  # noqa: PLC0415
-
-                        _anon_body = json.dumps(report_payload).encode()
-                        _anon_req = _ur.Request(
-                            f"{SUPABASE_URL}/rest/v1/reports",
-                            data=_anon_body,
-                            headers={
-                                "Content-Type": "application/json",
-                                "apikey": SUPABASE_ANON_KEY,
-                                "Authorization": f"Bearer {SUPABASE_ANON_KEY}",
-                                "Prefer": "return=minimal",
-                            },
-                            method="POST",
+                        from argus.cloud import (  # noqa: PLC0415
+                            SUPABASE_ANON_KEY,
+                            SUPABASE_URL,
+                            _get_valid_credentials,
+                            _supabase_request,
                         )
-                        _ur.urlopen(_anon_req, timeout=5)
-                        supabase_ok = True
+
+                        creds = _get_valid_credentials()
+                        if creds:
+                            report_payload["user_id"] = creds.user_id
+                            _supabase_request(
+                                creds.access_token,
+                                "reports",
+                                method="POST",
+                                body=report_payload,
+                                extra_headers={"Prefer": "return=minimal"},
+                            )
+                            supabase_ok = True
+                        else:
+                            # Fallback: use anon key so reports work without login
+                            import urllib.request as _ur  # noqa: PLC0415
+
+                            _anon_body = json.dumps(report_payload).encode()
+                            _anon_req = _ur.Request(
+                                f"{SUPABASE_URL}/rest/v1/reports",
+                                data=_anon_body,
+                                headers={
+                                    "Content-Type": "application/json",
+                                    "apikey": SUPABASE_ANON_KEY,
+                                    "Authorization": f"Bearer {SUPABASE_ANON_KEY}",
+                                    "Prefer": "return=minimal",
+                                },
+                                method="POST",
+                            )
+                            _ur.urlopen(_anon_req, timeout=5)
+                            supabase_ok = True
                 except Exception:
                     pass  # Supabase upload is best-effort
 

--- a/src/argus/cli/main.py
+++ b/src/argus/cli/main.py
@@ -17,6 +17,7 @@ except ImportError:
 
 from argus.cli.cmd_diff import diff_runs
 from argus.cli.cmd_doctor import doctor
+from argus.cli.cmd_key import key_clear, key_set, key_show
 from argus.cli.cmd_locate import locate_sources
 from argus.cli.cmd_login import login, logout, whoami
 from argus.cli.cmd_open_ui import open_ui
@@ -35,6 +36,32 @@ app = typer.Typer(
 
 open_app = typer.Typer(help="Open Argus tools.", no_args_is_help=True)
 app.add_typer(open_app, name="open")
+
+key_app = typer.Typer(help="Manage your BYOK OpenAI API key.", no_args_is_help=True)
+app.add_typer(key_app, name="key")
+
+
+@key_app.command("set")
+def cmd_key_set(
+    value: Annotated[
+        Optional[str],
+        typer.Argument(help="OpenAI API key. Omit to be prompted with hidden input."),
+    ] = None,
+) -> None:
+    """Save your OpenAI API key locally (~/.argus/config.json)."""
+    key_set(value)
+
+
+@key_app.command("show")
+def cmd_key_show() -> None:
+    """Show the currently resolved key (masked) and its source."""
+    key_show()
+
+
+@key_app.command("clear")
+def cmd_key_clear() -> None:
+    """Remove the saved local key."""
+    key_clear()
 
 _console = Console()
 
@@ -68,6 +95,7 @@ _COMMANDS = [
     ("login", "sign in with Google to sync runs to the cloud"),
     ("logout", "clear stored credentials"),
     ("whoami", "show current login status"),
+    ("key set", "save your OpenAI API key locally for BYOK mode"),
     ("update", "check GitHub for a newer release and upgrade"),
     ("doctor", "diagnose integration issues (LangGraph, storage)"),
 ]

--- a/src/argus/cli/main.py
+++ b/src/argus/cli/main.py
@@ -43,10 +43,9 @@ app.add_typer(key_app, name="key")
 
 @key_app.command("set")
 def cmd_key_set(
-    value: Annotated[
-        Optional[str],
-        typer.Argument(help="OpenAI API key. Omit to be prompted with hidden input."),
-    ] = None,
+    value: Optional[str] = typer.Argument(
+        None, help="OpenAI API key. Omit to be prompted with hidden input."
+    ),
 ) -> None:
     """Save your OpenAI API key locally (~/.argus/config.json)."""
     key_set(value)

--- a/src/argus/cli/main.py
+++ b/src/argus/cli/main.py
@@ -71,6 +71,7 @@ _WORDMARK = [
 ]
 
 _SETUP_LINES = [
+    ("argus key set <openai-key>", "# optional: enable AI-powered detection (BYOK)"),
     ("from argus import ArgusWatcher", ""),
     ("watcher = ArgusWatcher()", ""),
     ("watcher.watch(graph)", "# graph = your StateGraph, before .compile()"),

--- a/src/argus/cloud.py
+++ b/src/argus/cloud.py
@@ -6,6 +6,7 @@ Uses only stdlib (urllib) to avoid adding dependencies.
 from __future__ import annotations
 
 import json
+import os
 import threading
 import time
 import urllib.error
@@ -14,14 +15,9 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-# ── Public Supabase config (safe to embed — RLS protects data) ───────────
-SUPABASE_URL = "https://isnphpbckxfjsxllryrg.supabase.co"
-SUPABASE_ANON_KEY = (
-    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9."
-    "eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImlzbnBocGJja3hmanN4bGxyeXJnIiwi"
-    "cm9sZSI6ImFub24iLCJpYXQiOjE3Nzc0MDcxNjQsImV4cCI6MjA5Mjk4MzE2NH0."
-    "nfaMxbDL9E8gyvV7k2r6F8PQhAcxdZ4QVlkVWloJ88Q"
-)
+# ── Supabase config (hosted deployments set these via cloud/config.py) ────
+SUPABASE_URL = os.environ.get("ARGUS_SUPABASE_URL")
+SUPABASE_ANON_KEY = os.environ.get("ARGUS_SUPABASE_ANON_KEY")
 
 _CREDENTIALS_DIR = Path.home() / ".argus"
 _CREDENTIALS_FILE = _CREDENTIALS_DIR / "credentials.json"
@@ -73,6 +69,8 @@ def clear_credentials() -> None:
 
 
 def is_logged_in() -> bool:
+    if SUPABASE_URL is None:
+        return False
     creds = load_credentials()
     return creds is not None
 
@@ -80,12 +78,14 @@ def is_logged_in() -> bool:
 # ── Token refresh ────────────────────────────────────────────────────────
 
 
-def _refresh_if_needed(creds: Credentials) -> Credentials:
+def _refresh_if_needed(creds: Credentials) -> Credentials | None:
     """Refresh the access token if it expires within 60 seconds."""
     if time.time() < creds.expires_at - 60:
         return creds
 
     try:
+        if SUPABASE_ANON_KEY is None:
+            return None
         body = json.dumps({"refresh_token": creds.refresh_token}).encode()
         req = urllib.request.Request(
             f"{SUPABASE_URL}/auth/v1/token?grant_type=refresh_token",
@@ -113,6 +113,8 @@ def _refresh_if_needed(creds: Credentials) -> Credentials:
 
 
 def _get_valid_credentials() -> Credentials | None:
+    if SUPABASE_URL is None:
+        return None
     creds = load_credentials()
     if creds is None:
         return None
@@ -131,6 +133,8 @@ def _supabase_request(
     extra_headers: dict[str, str] | None = None,
 ) -> Any:
     """Make an authenticated request to the Supabase REST API."""
+    if SUPABASE_ANON_KEY is None:
+        raise RuntimeError("ARGUS_SUPABASE_ANON_KEY not configured")
     url = f"{SUPABASE_URL}/rest/v1/{path}"
     headers = {
         "apikey": SUPABASE_ANON_KEY,

--- a/src/argus/embedding_store.py
+++ b/src/argus/embedding_store.py
@@ -43,7 +43,10 @@ def _get_client() -> Any:
             pass
         from openai import OpenAI  # noqa: PLC0415
 
-        _client = OpenAI()
+        from argus.user_config import resolve_openai_key  # noqa: PLC0415
+
+        key = resolve_openai_key()
+        _client = OpenAI(api_key=key) if key else OpenAI()
         return _client
 
 

--- a/src/argus/llm_proxy.py
+++ b/src/argus/llm_proxy.py
@@ -1,10 +1,14 @@
-"""Route all LLM calls through the ARGUS proxy (Supabase Edge Function).
+"""LLM calls with BYOK-first resolution.
 
-All calls go through the proxy using the ARGUS-provided key. Users never
-need their own OpenAI key. The user must be logged in via `argus login`.
+Priority:
+  1. OPENAI_API_KEY env var         -> call OpenAI directly (BYOK)
+  2. saved key (~/.argus/config)    -> call OpenAI directly (BYOK)
+  3. logged in + Supabase configured -> route through the ARGUS proxy
+  4. none of the above              -> {"error": ...}; callers fall back to
+                                       heuristic-only detection.
 
-This module exposes a single function: `create_chat_completion()` which
-mirrors the OpenAI chat completions API shape.
+Exposes create_chat_completion() mirroring the OpenAI chat completions shape.
+Uses only stdlib urllib — no new dependency.
 """
 
 from __future__ import annotations
@@ -15,13 +19,55 @@ import urllib.request
 from typing import Any
 
 from argus.cloud import SUPABASE_URL, _get_valid_credentials
+from argus.user_config import resolve_openai_key
 
-_PROXY_URL = f"{SUPABASE_URL}/functions/v1/llm-proxy"
+_PROXY_URL = f"{SUPABASE_URL}/functions/v1/llm-proxy" if SUPABASE_URL else None
+_OPENAI_URL = "https://api.openai.com/v1/chat/completions"
 
 
-def _has_own_key() -> bool:
-    """Deprecated — always returns False. All calls go through the proxy."""
-    return False
+def _call_openai_direct(
+    *,
+    api_key: str,
+    model: str,
+    messages: list[dict[str, str]],
+    max_tokens: int = 2000,
+    temperature: float = 0.3,
+    response_format: dict[str, str] | None = None,
+    timeout: float = 30.0,
+) -> dict[str, Any]:
+    """Call OpenAI's chat completions endpoint directly with the user's key."""
+    payload: dict[str, Any] = {
+        "model": model,
+        "messages": messages,
+        "max_tokens": max_tokens,
+        "temperature": temperature,
+    }
+    if response_format:
+        payload["response_format"] = response_format
+
+    req = urllib.request.Request(
+        _OPENAI_URL,
+        data=json.dumps(payload).encode(),
+        headers={
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {api_key}",
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            result: dict[str, Any] = json.loads(resp.read())
+            return result
+    except urllib.error.HTTPError as exc:
+        try:
+            body = json.loads(exc.read())
+            msg = body.get("error", {})
+            msg = msg.get("message") if isinstance(msg, dict) else msg
+            return {"error": msg or f"OpenAI HTTP {exc.code}"}
+        except Exception:
+            return {"error": f"OpenAI HTTP {exc.code}"}
+    except Exception as exc:
+        return {"error": f"OpenAI error: {exc}"}
 
 
 def _call_proxy(
@@ -33,10 +79,13 @@ def _call_proxy(
     response_format: dict[str, str] | None = None,
     timeout: float = 30.0,
 ) -> dict[str, Any]:
-    """Call the ARGUS LLM proxy edge function."""
+    """Call the ARGUS LLM proxy edge function (hosted deployments only)."""
+    if not SUPABASE_URL or _PROXY_URL is None:
+        return {"error": "No LLM configured. Set OPENAI_API_KEY or run: argus key set"}
+
     creds = _get_valid_credentials()
     if creds is None:
-        return {"error": "Not logged in. Run: argus login"}
+        return {"error": "No LLM configured. Set OPENAI_API_KEY or run: argus key set"}
 
     payload: dict[str, Any] = {
         "model": model,
@@ -47,20 +96,19 @@ def _call_proxy(
     if response_format:
         payload["response_format"] = response_format
 
-    data = json.dumps(payload).encode()
     req = urllib.request.Request(
         _PROXY_URL,
-        data=data,
+        data=json.dumps(payload).encode(),
         headers={
             "Content-Type": "application/json",
             "Authorization": f"Bearer {creds.access_token}",
         },
         method="POST",
     )
-
     try:
         with urllib.request.urlopen(req, timeout=timeout) as resp:
-            return json.loads(resp.read())
+            result: dict[str, Any] = json.loads(resp.read())
+            return result
     except urllib.error.HTTPError as exc:
         try:
             body = json.loads(exc.read())
@@ -81,15 +129,22 @@ def create_chat_completion(
     api_key: str | None = None,
     timeout: float = 30.0,
 ) -> dict[str, Any]:
-    """Create a chat completion via the ARGUS proxy.
-
-    All LLM calls are routed through the Supabase Edge Function proxy
-    which uses the ARGUS-provided OpenAI key. Users never need their own key.
-    Requires the user to be logged in via `argus login`.
+    """Create a chat completion via BYOK direct call, else the hosted proxy.
 
     Returns the raw OpenAI response dict on success, or {"error": "..."} on
-    failure.  Callers should check for the "error" key.
+    failure. Callers should check for the "error" key.
     """
+    key = api_key or resolve_openai_key()
+    if key:
+        return _call_openai_direct(
+            api_key=key,
+            model=model,
+            messages=messages,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            response_format=response_format,
+            timeout=timeout,
+        )
     return _call_proxy(
         model=model,
         messages=messages,
@@ -101,6 +156,9 @@ def create_chat_completion(
 
 
 def is_available() -> bool:
-    """Return True if LLM calls can be made (user is logged in)."""
-    creds = _get_valid_credentials()
-    return creds is not None
+    """True if any LLM path is usable: BYOK key, or logged-in hosted proxy."""
+    if resolve_openai_key():
+        return True
+    if not SUPABASE_URL:
+        return False
+    return _get_valid_credentials() is not None

--- a/src/argus/user_config.py
+++ b/src/argus/user_config.py
@@ -1,0 +1,60 @@
+"""Local user config for BYOK (bring-your-own-key).
+
+Stores the user's OpenAI API key at ~/.argus/config.json (chmod 600) so it
+persists across sessions. The environment variable OPENAI_API_KEY always wins
+over the saved key (12-factor override).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+_CONFIG_DIR = Path.home() / ".argus"
+_CONFIG_FILE = _CONFIG_DIR / "config.json"
+
+
+def _read() -> dict[str, Any]:
+    if not _CONFIG_FILE.exists():
+        return {}
+    try:
+        data: dict[str, Any] = json.loads(_CONFIG_FILE.read_text(encoding="utf-8"))
+        return data
+    except Exception:
+        return {}
+
+
+def _write(data: dict[str, Any]) -> None:
+    _CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+    _CONFIG_FILE.write_text(json.dumps(data, indent=2), encoding="utf-8")
+    _CONFIG_FILE.chmod(0o600)
+
+
+def get_saved_openai_key() -> str | None:
+    """Return the OpenAI key saved on disk, or None."""
+    key = _read().get("openai_api_key")
+    return key or None
+
+
+def set_openai_key(key: str) -> None:
+    """Persist the OpenAI key to ~/.argus/config.json (chmod 600)."""
+    data = _read()
+    data["openai_api_key"] = key.strip()
+    _write(data)
+
+
+def clear_openai_key() -> None:
+    """Remove the saved OpenAI key."""
+    data = _read()
+    data.pop("openai_api_key", None)
+    _write(data)
+
+
+def resolve_openai_key() -> str | None:
+    """Resolve the OpenAI key: env OPENAI_API_KEY first, then saved key."""
+    env = os.environ.get("OPENAI_API_KEY")
+    if env:
+        return env
+    return get_saved_openai_key()

--- a/tests/test_db_flow.py
+++ b/tests/test_db_flow.py
@@ -198,7 +198,14 @@ def test_3_private_db_flags_next_run():
 
 
 def test_4_public_approval(monkeypatch):
-    """Sharing a candidate writes it to the shared cache (simulating Supabase push)."""
+    """Sharing a candidate writes it to the shared cache (simulating Supabase push).
+
+    Public sharing is an enterprise/configured feature: with no Supabase
+    configured (open-source), approve_candidate_shared falls back to a local
+    approval. This test exercises the configured/enterprise path, so it sets
+    a Supabase URL.
+    """
+    monkeypatch.setattr("argus.cloud.SUPABASE_URL", "https://test.supabase.co")
     sig2 = _make_sig("[SYSTEM PROMPT LEAKED]", category="suspicious_phrases")
     cand_id = add_candidate(sig2, run_id="run-002", node_name="rag_retriever")
 
@@ -329,6 +336,10 @@ def test_6_rejected_pattern_not_requeued():
 def test_7_full_loop_report(monkeypatch, capsys):
     """Runs the complete learning loop in one test and prints a final report."""
     results: dict[str, bool] = {}
+
+    # Public sharing is enterprise/configured — set a Supabase URL so the
+    # shared-approval path runs (open-source with no URL falls back to local).
+    monkeypatch.setattr("argus.cloud.SUPABASE_URL", "https://test.supabase.co")
 
     # ── Step 1: LLM suggests trend (private) ──
     private_sig = _make_sig("ARGUS_PRIVATE_TREND")

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1222,3 +1222,31 @@ def test_cli_key_set_accepts_positional_value(tmp_path, monkeypatch):
     result = CliRunner().invoke(app, ["key", "set", "sk-positional-123456"])
     assert result.exit_code == 0, result.output
     assert uc.get_saved_openai_key() == "sk-positional-123456"
+
+
+@pytest.mark.unit
+def test_approve_shared_falls_back_to_local_when_no_cloud(tmp_path, monkeypatch):
+    """OSS/local-only: approving a trend for 'sharing' with no Supabase configured
+    must store it locally (no public/private split), not silently fail."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".argus").mkdir(exist_ok=True)
+    import argus.cloud as cloud
+    monkeypatch.setattr(cloud, "SUPABASE_URL", None)
+
+    from argus.models import SuggestedSignature
+    import argus.candidate_store as cs
+
+    sig = SuggestedSignature(
+        pattern="placeholder local fallback test",
+        match_strategy="contains_ci",
+        proposed_category="placeholder_outputs",
+        severity="high",
+        description="d",
+        evidence=("e",),
+        confidence=0.9,
+        reasoning="r",
+    )
+    cid = cs.add_candidate(sig, "run-1")
+    res = cs.approve_candidate_shared(cid)
+    assert res is not None  # did not fail
+    assert (tmp_path / ".argus" / "custom_signatures.json").exists()  # stored locally

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1083,7 +1083,9 @@ def test_llm_proxy_uses_byok_when_key_present(monkeypatch):
     monkeypatch.setattr(lp, "_call_openai_direct", fake_direct)
     monkeypatch.setattr(lp, "resolve_openai_key", lambda: "sk-byok")
 
-    out = lp.create_chat_completion(model="gpt-4o-mini", messages=[{"role": "user", "content": "hi"}])
+    out = lp.create_chat_completion(
+        model="gpt-4o-mini", messages=[{"role": "user", "content": "hi"}]
+    )
     assert "error" not in out
     assert captured["api_key"] == "sk-byok"
     assert captured["model"] == "gpt-4o-mini"
@@ -1096,7 +1098,9 @@ def test_llm_proxy_errors_when_no_key_and_no_proxy(monkeypatch):
     monkeypatch.setattr(lp, "resolve_openai_key", lambda: None)
     monkeypatch.setattr(lp, "SUPABASE_URL", None)
 
-    out = lp.create_chat_completion(model="gpt-4o-mini", messages=[{"role": "user", "content": "hi"}])
+    out = lp.create_chat_completion(
+        model="gpt-4o-mini", messages=[{"role": "user", "content": "hi"}]
+    )
     assert "error" in out
 
 
@@ -1147,8 +1151,8 @@ def test_login_reports_hosted_only_when_unconfigured(monkeypatch, capsys):
 
 @pytest.mark.unit
 def test_cmd_key_set_show_clear(tmp_path, monkeypatch, capsys):
-    import argus.user_config as uc
     import argus.cli.cmd_key as ck
+    import argus.user_config as uc
 
     monkeypatch.setattr(uc, "_CONFIG_DIR", tmp_path / ".argus")
     monkeypatch.setattr(uc, "_CONFIG_FILE", tmp_path / ".argus" / "config.json")
@@ -1178,7 +1182,8 @@ def test_embedding_client_uses_resolved_key(monkeypatch):
 
     monkeypatch.setattr(es, "_client", None)
     monkeypatch.setattr("argus.user_config.resolve_openai_key", lambda: "sk-embed")
-    import sys, types
+    import sys
+    import types
     fake_mod = types.ModuleType("openai")
     fake_mod.OpenAI = FakeOpenAI
     monkeypatch.setitem(sys.modules, "openai", fake_mod)
@@ -1233,8 +1238,8 @@ def test_approve_shared_falls_back_to_local_when_no_cloud(tmp_path, monkeypatch)
     import argus.cloud as cloud
     monkeypatch.setattr(cloud, "SUPABASE_URL", None)
 
-    from argus.models import SuggestedSignature
     import argus.candidate_store as cs
+    from argus.models import SuggestedSignature
 
     sig = SuggestedSignature(
         pattern="placeholder local fallback test",

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1164,3 +1164,24 @@ def test_cmd_key_set_show_clear(tmp_path, monkeypatch, capsys):
 
     ck.key_clear()
     assert uc.get_saved_openai_key() is None
+
+
+@pytest.mark.unit
+def test_embedding_client_uses_resolved_key(monkeypatch):
+    import argus.embedding_store as es
+
+    captured = {}
+
+    class FakeOpenAI:
+        def __init__(self, api_key=None):
+            captured["api_key"] = api_key
+
+    monkeypatch.setattr(es, "_client", None)
+    monkeypatch.setattr("argus.user_config.resolve_openai_key", lambda: "sk-embed")
+    import sys, types
+    fake_mod = types.ModuleType("openai")
+    fake_mod.OpenAI = FakeOpenAI
+    monkeypatch.setitem(sys.modules, "openai", fake_mod)
+
+    es._get_client()
+    assert captured["api_key"] == "sk-embed"

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1112,3 +1112,24 @@ def test_llm_proxy_is_available_true_with_byok(monkeypatch):
     importlib.reload(lp)
     monkeypatch.setattr(lp, "resolve_openai_key", lambda: "sk-byok")
     assert lp.is_available() is True
+
+
+@pytest.mark.unit
+def test_cloud_no_hardcoded_supabase_url():
+    import inspect
+
+    import argus.cloud as cloud
+
+    src = inspect.getsource(cloud)
+    assert "isnphpbckxfjsxllryrg" not in src  # real project ref must be gone
+
+
+@pytest.mark.unit
+def test_cloud_noops_when_unconfigured(monkeypatch):
+    import argus.cloud as cloud
+
+    monkeypatch.setattr(cloud, "SUPABASE_URL", None)
+    monkeypatch.setattr(cloud, "SUPABASE_ANON_KEY", None)
+    assert cloud.is_logged_in() is False
+    assert cloud.push_run({"run_id": "x"}) is False
+    assert cloud.pull_shared_signatures() == []

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1133,3 +1133,13 @@ def test_cloud_noops_when_unconfigured(monkeypatch):
     assert cloud.is_logged_in() is False
     assert cloud.push_run({"run_id": "x"}) is False
     assert cloud.pull_shared_signatures() == []
+
+
+@pytest.mark.unit
+def test_login_reports_hosted_only_when_unconfigured(monkeypatch, capsys):
+    import argus.cli.cmd_login as cl
+
+    monkeypatch.setattr(cl, "SUPABASE_URL", None)
+    cl.login()
+    out = capsys.readouterr().out.lower()
+    assert "hosted" in out or "not available" in out

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1204,3 +1204,21 @@ def test_doctor_llm_mode_heuristic(monkeypatch):
     monkeypatch.setattr("argus.cloud.SUPABASE_URL", None)
     ok, msg = d._check_llm_mode()
     assert "heuristic" in msg.lower()
+
+
+@pytest.mark.unit
+def test_cli_key_set_accepts_positional_value(tmp_path, monkeypatch):
+    """Regression: `argus key set <value>` must register VALUE as a positional
+    argument (not a --value option), so the key is actually persisted."""
+    from typer.testing import CliRunner
+
+    import argus.user_config as uc
+    from argus.cli.main import app
+
+    monkeypatch.setattr(uc, "_CONFIG_DIR", tmp_path / ".argus")
+    monkeypatch.setattr(uc, "_CONFIG_FILE", tmp_path / ".argus" / "config.json")
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    result = CliRunner().invoke(app, ["key", "set", "sk-positional-123456"])
+    assert result.exit_code == 0, result.output
+    assert uc.get_saved_openai_key() == "sk-positional-123456"

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1185,3 +1185,22 @@ def test_embedding_client_uses_resolved_key(monkeypatch):
 
     es._get_client()
     assert captured["api_key"] == "sk-embed"
+
+
+@pytest.mark.unit
+def test_doctor_llm_mode_byok(monkeypatch):
+    import argus.cli.cmd_doctor as d
+    monkeypatch.setattr("argus.user_config.resolve_openai_key", lambda: "sk-x")
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-x")
+    ok, msg = d._check_llm_mode()
+    assert ok is True
+    assert "BYOK" in msg
+
+
+@pytest.mark.unit
+def test_doctor_llm_mode_heuristic(monkeypatch):
+    import argus.cli.cmd_doctor as d
+    monkeypatch.setattr("argus.user_config.resolve_openai_key", lambda: None)
+    monkeypatch.setattr("argus.cloud.SUPABASE_URL", None)
+    ok, msg = d._check_llm_mode()
+    assert "heuristic" in msg.lower()

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1143,3 +1143,24 @@ def test_login_reports_hosted_only_when_unconfigured(monkeypatch, capsys):
     cl.login()
     out = capsys.readouterr().out.lower()
     assert "hosted" in out or "not available" in out
+
+
+@pytest.mark.unit
+def test_cmd_key_set_show_clear(tmp_path, monkeypatch, capsys):
+    import argus.user_config as uc
+    import argus.cli.cmd_key as ck
+
+    monkeypatch.setattr(uc, "_CONFIG_DIR", tmp_path / ".argus")
+    monkeypatch.setattr(uc, "_CONFIG_FILE", tmp_path / ".argus" / "config.json")
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    ck.key_set("sk-abcdef123456")
+    assert uc.get_saved_openai_key() == "sk-abcdef123456"
+
+    ck.key_show()
+    out = capsys.readouterr().out
+    assert "sk-abcdef123456" not in out  # masked
+    assert "3456" in out  # last 4 shown
+
+    ck.key_clear()
+    assert uc.get_saved_openai_key() is None

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1066,3 +1066,49 @@ def test_resolve_openai_key_prefers_env(tmp_path, monkeypatch):
     assert uc.resolve_openai_key() == "sk-env"
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     assert uc.resolve_openai_key() == "sk-saved"
+
+
+@pytest.mark.unit
+def test_llm_proxy_uses_byok_when_key_present(monkeypatch):
+    import argus.llm_proxy as lp
+
+    captured = {}
+
+    def fake_direct(*, api_key, model, messages, max_tokens, temperature,
+                    response_format, timeout):
+        captured["api_key"] = api_key
+        captured["model"] = model
+        return {"choices": [{"message": {"content": "ok"}}]}
+
+    monkeypatch.setattr(lp, "_call_openai_direct", fake_direct)
+    monkeypatch.setattr(lp, "resolve_openai_key", lambda: "sk-byok")
+
+    out = lp.create_chat_completion(model="gpt-4o-mini", messages=[{"role": "user", "content": "hi"}])
+    assert "error" not in out
+    assert captured["api_key"] == "sk-byok"
+    assert captured["model"] == "gpt-4o-mini"
+
+
+@pytest.mark.unit
+def test_llm_proxy_errors_when_no_key_and_no_proxy(monkeypatch):
+    import argus.llm_proxy as lp
+
+    monkeypatch.setattr(lp, "resolve_openai_key", lambda: None)
+    monkeypatch.setattr(lp, "SUPABASE_URL", None)
+
+    out = lp.create_chat_completion(model="gpt-4o-mini", messages=[{"role": "user", "content": "hi"}])
+    assert "error" in out
+
+
+@pytest.mark.unit
+def test_llm_proxy_is_available_true_with_byok(monkeypatch):
+    import importlib
+
+    import argus.llm_proxy as lp
+
+    # conftest's autouse fixture stubs is_available to always return False
+    # for test isolation elsewhere; reload restores the real implementation
+    # for this test only.
+    importlib.reload(lp)
+    monkeypatch.setattr(lp, "resolve_openai_key", lambda: "sk-byok")
+    assert lp.is_available() is True

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1034,3 +1034,35 @@ def test_conditional_branch_auto_finalize():
     record = load_run(session.run_id)
     assert record is not None
     assert record.overall_status == "clean"
+
+
+@pytest.mark.unit
+def test_user_config_save_load_clear(tmp_path, monkeypatch):
+    import argus.user_config as uc
+
+    monkeypatch.setattr(uc, "_CONFIG_DIR", tmp_path / ".argus")
+    monkeypatch.setattr(uc, "_CONFIG_FILE", tmp_path / ".argus" / "config.json")
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    assert uc.get_saved_openai_key() is None
+    uc.set_openai_key("sk-test-123")
+    assert uc.get_saved_openai_key() == "sk-test-123"
+    # file is chmod 600
+    import stat
+    mode = stat.S_IMODE((tmp_path / ".argus" / "config.json").stat().st_mode)
+    assert mode == 0o600
+    uc.clear_openai_key()
+    assert uc.get_saved_openai_key() is None
+
+
+@pytest.mark.unit
+def test_resolve_openai_key_prefers_env(tmp_path, monkeypatch):
+    import argus.user_config as uc
+
+    monkeypatch.setattr(uc, "_CONFIG_DIR", tmp_path / ".argus")
+    monkeypatch.setattr(uc, "_CONFIG_FILE", tmp_path / ".argus" / "config.json")
+    uc.set_openai_key("sk-saved")
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-env")
+    assert uc.resolve_openai_key() == "sk-env"
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    assert uc.resolve_openai_key() == "sk-saved"


### PR DESCRIPTION
## Open-core separation + BYOK (VAR-93)

Splits ARGUS into a free open-source core and a proprietary hosted layer **in the same repo**, and makes `pip install argus-agents` a fully working bring-your-own-key product with **no dependency on ARGUS infrastructure**. The hosted/enterprise deployment keeps working via env vars.

### What changed

**BYOK LLM layer**
- New `argus key set/show/clear` — saves your OpenAI key to `~/.argus/config.json`, reused every session.
- Resolution order: `OPENAI_API_KEY` env → saved key → hosted proxy (cloud tier) → heuristic-only. Callers unchanged (they already handle the error/degrade path).
- `embedding_store` uses the same BYOK-resolved key.

**Secrets out of the core**
- Supabase URL/anon key now read from `ARGUS_SUPABASE_URL` / `ARGUS_SUPABASE_ANON_KEY`; the core no-ops cleanly when unset. Zero ARGUS Supabase URL in any `src/argus/*.py`.
- Hosted values live in the new `cloud/` (config + `apply_env()`), auto-activated when the full repo is present; open-source pip never ships `cloud/`.
- `argus login` is guarded (hosted-only message when unconfigured); `argus doctor` reports `BYOK / hosted / heuristic-only`.

**Trends (learned signatures)**
- Open-source: everything stays local (no dead public/private option) — `approve_candidate_shared` falls back to local when no Supabase.
- Enterprise: public → hosted Supabase, private → local (unchanged when configured).

**Packaging / licensing**
- Dual-licensed: core `src/argus/` under **Apache-2.0**, `cloud/` proprietary. `cloud/` excluded from sdist + wheel (build-verified).

**Docs**
- README: BYOK section, `argus key` commands, install now `argus-agents[all]`. New `cloud/README.md` (enterprise).

### Verification
- **382 tests pass**, ruff clean, our changed files add zero new mypy errors.
- Verified in a **clean wheel install** (outside the repo, no `cloud/`): detection + local storage + `argus key set` → `doctor` → `BYOK (saved)`, `argus ui` local-only, `login` graceful.
- Build proven to exclude `cloud/` and include `argus`.

### Known follow-ups (not blocking)
- Compiled UI bundle `src/argus/ui_dist/*.js` still embeds the hosted Supabase URL (public-safe anon values) — needs a `website/` rebuild to be fully hosted-reference-free.
- A live enterprise `argus login` + cloud-sync run (needs a real authenticated session) is the one path not verifiable headlessly.

Full design + plan: `docs/superpowers/specs/` and `docs/superpowers/plans/`.
