### PR TITLE
Fix argus fix Bugbot findings from #15

### DIFF
--- a/src/argus/fix_prompt.py
+++ b/src/argus/fix_prompt.py
@@ -49,12 +49,9 @@ _STATUS_PLAIN = {
     "crashed": "raised an error and stopped",
     "fail": "produced output missing fields the next node requires",
     "degraded_input": (
-        "ran with incomplete input because an earlier node did not produce "
-        "a field it needed"
+        "ran with incomplete input because an earlier node did not produce a field it needed"
     ),
-    "semantic_fail": (
-        "produced output that looks structurally correct but is wrong in content"
-    ),
+    "semantic_fail": ("produced output that looks structurally correct but is wrong in content"),
     "interrupted": "was interrupted before it finished",
     "pass": "completed without an error being raised",
     "retried": "was retried",
@@ -123,9 +120,7 @@ def build_fix_prompt_for_record(
     event = _find_node_event(record, target)
 
     if event is None:
-        raise FixPromptError(
-            f"Node '{target}' has no recorded step in run {record.run_id}."
-        )
+        raise FixPromptError(f"Node '{target}' has no recorded step in run {record.run_id}.")
 
     if not _has_failure_signal(event):
         raise FixPromptError(
@@ -156,19 +151,17 @@ def build_fix_prompt_for_record(
 def _resolve_target_node(record: RunRecord, node: Optional[str]) -> str:
     """Explicit node → root-cause origin → first failing step."""
     if node:
-        known = set(record.graph_node_names or []) | {
-            e.node_name for e in record.steps
-        }
+        known = set(record.graph_node_names or []) | {e.node_name for e in record.steps}
         if node not in known:
             available = ", ".join(sorted(known)) or "(none recorded)"
             raise FixPromptError(
-                f"Node '{node}' is not part of run {record.run_id}. "
-                f"Available nodes: {available}"
+                f"Node '{node}' is not part of run {record.run_id}. Available nodes: {available}"
             )
         return node
 
-    # root_cause_chain is built by walking backward to the origin and is stored
-    # in chronological order of first occurrence — chain[0] is the origin.
+    # chain[0] is the inspector origin (chronological walk) and, after
+    # correlation overwrites the field with degradation_origins, the
+    # highest-confidence onset. Either way it is the node to fix.
     if record.root_cause_chain:
         return record.root_cause_chain[0]
 
@@ -204,19 +197,18 @@ def _find_symptom_event(record: RunRecord, target: str) -> Optional[NodeEvent]:
     """
     crashed = [e for e in record.steps if e.status == "crashed"]
     downstream_crashes = [
-        e
-        for e in crashed
-        if e.node_name != target and _is_reachable(record, target, e.node_name)
+        e for e in crashed if e.node_name != target and _is_reachable(record, target, e.node_name)
     ]
     if downstream_crashes:
         return max(downstream_crashes, key=lambda e: e.step_index)
 
     # Same constraint applies to both fallbacks below: they were written
-    # assuming target is the chain origin, where first_failure_step/chain[-1]
-    # naturally sit downstream. Under a --node override to a non-origin
-    # node, an unconstrained fallback can point *upstream* of target —
-    # exactly the false-exoneration bug the reachability check above exists
-    # to prevent, just via a different path.
+    # assuming target is the chain origin, where first_failure_step / the
+    # last hop of a real propagation path naturally sit downstream. Under
+    # a --node override to a non-origin node, an unconstrained fallback
+    # can point *upstream* of target — exactly the false-exoneration bug
+    # the reachability check above exists to prevent, just via a
+    # different path.
     if (
         record.first_failure_step
         and record.first_failure_step != target
@@ -224,15 +216,55 @@ def _find_symptom_event(record: RunRecord, target: str) -> Optional[NodeEvent]:
     ):
         return _find_node_event(record, record.first_failure_step)
 
-    chain = record.root_cause_chain or []
-    if (
-        len(chain) > 1
-        and chain[-1] != target
-        and _is_reachable(record, target, chain[-1])
-    ):
-        return _find_node_event(record, chain[-1])
+    path = _propagation_nodes(record, target)
+    if len(path) > 1 and path[-1] != target and _is_reachable(record, target, path[-1]):
+        return _find_node_event(record, path[-1])
 
     return None
+
+
+# session.py overwrites root_cause_chain with degradation_origins only
+# when the top origin's confidence is at least this. Must stay in sync.
+_CORRELATION_CHAIN_OVERRIDE_MIN = 0.8
+
+
+def _chain_is_ranked_origins(record: RunRecord) -> bool:
+    """True when root_cause_chain is confidence-ranked onsets, not a path.
+
+    ``session.py`` replaces the inspector walk with
+    ``[o.node_name for o in correlation.degradation_origins]`` once the
+    top origin is high-confidence. Those names are independent onset
+    candidates — using the last one as the crash site, or joining them
+    with ``→``, invents a propagation that was never recorded.
+    """
+    corr = record.correlation
+    if corr is None or not corr.degradation_origins:
+        return False
+    if corr.degradation_origins[0].confidence < _CORRELATION_CHAIN_OVERRIDE_MIN:
+        return False
+    return list(record.root_cause_chain or []) == [o.node_name for o in corr.degradation_origins]
+
+
+def _propagation_nodes(record: RunRecord, target: str) -> list[str]:
+    """Origin→symptom node list, or empty when we only have ranked onsets."""
+    if not _chain_is_ranked_origins(record):
+        return list(record.root_cause_chain or [])
+
+    corr = record.correlation
+    if corr is None:
+        return []
+
+    matching = [
+        list(chain.nodes)
+        for chain in corr.propagation_chains
+        if target in chain.nodes and len(chain.nodes) > 1
+    ]
+    if not matching:
+        return []
+    for nodes in matching:
+        if nodes[0] == target:
+            return nodes
+    return matching[0]
 
 
 def _has_failure_signal(event: NodeEvent) -> bool:
@@ -364,9 +396,7 @@ def _reanchor(file_part: str) -> Optional[str]:
         # Mirror source_locator's walk rule: its named excludes *and* every
         # dot-directory (.pytest_cache, .direnv, .cache, ...), not just the
         # ones that happen to be listed.
-        return any(
-            part in _EXCLUDE_DIRS or part.startswith(".") for part in parts[:-1]
-        )
+        return any(part in _EXCLUDE_DIRS or part.startswith(".") for part in parts[:-1])
 
     matches = sorted(
         p for p in Path.cwd().rglob(name) if not _is_noise(p.relative_to(Path.cwd()).parts)
@@ -578,9 +608,7 @@ def _join_names(names: list[str]) -> str:
     return ", ".join(ticked[:-1]) + f" and {ticked[-1]}"
 
 
-def _headline(
-    record: RunRecord, target: str, event: NodeEvent, *, sanitized: bool
-) -> str:
+def _headline(record: RunRecord, target: str, event: NodeEvent, *, sanitized: bool) -> str:
     """One-line symptom for the title. Most concrete signal wins."""
     insp = event.inspection
 
@@ -602,10 +630,7 @@ def _headline(
             succ = _successors(record, target)
             field = _inline(insp.missing_fields[0], 80)
             if len(succ) == 1:
-                return (
-                    f"`{target}` does not produce the `{field}` field that "
-                    f"`{succ[0]}` needs"
-                )
+                return f"`{target}` does not produce the `{field}` field that `{succ[0]}` needs"
             return f"`{target}` does not produce the `{field}` field"
         if insp.empty_fields:
             return f"`{target}` produces an empty `{_inline(insp.empty_fields[0], 80)}`"
@@ -691,9 +716,8 @@ def _what_went_wrong(
     insp = event.inspection
 
     if event.status == "crashed":
-        paras.append(
-            f"`{target}` raised an error and stopped. The traceback is below."
-        )
+        below = "The exception type is below." if sanitized else "The traceback is below."
+        paras.append(f"`{target}` raised an error and stopped. {below}")
     elif event.status == "degraded_input" and insp is not None:
         upstream = insp.degraded_upstream_node or "an earlier node"
         fields = ", ".join(f"`{_inline(f, 80)}`" for f in insp.degraded_fields) or "a field"
@@ -703,18 +727,14 @@ def _what_went_wrong(
             "incomplete input."
         )
     else:
-        paras.append(
-            f"`{target}` ran without raising an error, but its output is wrong."
-        )
+        paras.append(f"`{target}` ran without raising an error, but its output is wrong.")
 
     if insp is None:
         return paras
 
     for tf in insp.tool_failures:
         plain = _TOOL_FAILURE_PLAIN.get(tf.failure_type, "the external call failed")
-        detail = (
-            "" if sanitized else (f" ({_inline(tf.evidence)})" if tf.evidence else "")
-        )
+        detail = "" if sanitized else (f" ({_inline(tf.evidence)})" if tf.evidence else "")
         paras.append(
             f"While producing `{_inline(tf.field_name, 80)}`, {plain}{detail}. The "
             "result was kept and passed on as if the call had succeeded."
@@ -761,9 +781,7 @@ def _what_went_wrong(
     for ss in insp.semantic_signals:
         where = _inline(ss.dotted_path, 80) or "the output"
         evidence = (
-            ""
-            if sanitized
-            else (f' Example: "{_inline(ss.evidence)}".' if ss.evidence else "")
+            "" if sanitized else (f' Example: "{_inline(ss.evidence)}".' if ss.evidence else "")
         )
         paras.append(f"In `{where}`: {_inline(ss.description)}.{evidence}")
 
@@ -775,9 +793,7 @@ def _what_went_wrong(
         if sanitized:
             paras.append(f"Expected {expected}, but the output did not match.")
         else:
-            paras.append(
-                f"Expected {expected}, but observed {_inline(a.observed_behavior)}."
-            )
+            paras.append(f"Expected {expected}, but observed {_inline(a.observed_behavior)}.")
 
     return paras
 
@@ -798,39 +814,26 @@ def _done_when(
         return _exception_type_name(exc) if sanitized else _exception_label(exc)
 
     if event.status == "crashed" and event.exception:
-        conds.append(
-            f"`{target}` runs to completion without raising "
-            f"{label(event.exception)}."
-        )
+        conds.append(f"`{target}` runs to completion without raising {label(event.exception)}.")
 
     if insp is not None:
         for tf in insp.tool_failures:
-            plain = _TOOL_FAILURE_CONDITION.get(
-                tf.failure_type, "the external call fails"
-            )
+            plain = _TOOL_FAILURE_CONDITION.get(tf.failure_type, "the external call fails")
             conds.append(
                 f"When {plain}, `{target}` either raises or retries — it never "
                 f"returns `{_inline(tf.field_name, 80)}` as a successful empty result."
             )
         for field in insp.missing_fields:
-            conds.append(
-                f"`{target}`'s output dict contains a `{_inline(field, 80)}` key."
-            )
+            conds.append(f"`{target}`'s output dict contains a `{_inline(field, 80)}` key.")
         for field in insp.empty_fields:
-            conds.append(
-                f"`{target}`'s `{_inline(field, 80)}` value is non-empty."
-            )
+            conds.append(f"`{target}`'s `{_inline(field, 80)}` value is non-empty.")
         for m in insp.type_mismatches:
-            conds.append(
-                f"`{_inline(m.field_name, 80)}` is {_inline(m.expected_type, 60)}."
-            )
+            conds.append(f"`{_inline(m.field_name, 80)}` is {_inline(m.expected_type, 60)}.")
         for ss in insp.semantic_signals:
             where = _inline(ss.dotted_path, 80) or "the output"
             # ss.description is registry prose; the raw category slug is an
             # internal enum and reads as broken grammar in a success criterion.
-            conds.append(
-                f"`{where}` no longer shows this problem: {_inline(ss.description)}."
-            )
+            conds.append(f"`{where}` no longer shows this problem: {_inline(ss.description)}.")
         # NOTE: degraded_fields deliberately produces no condition here. The
         # fix for a degraded node is in the upstream node that failed to
         # produce the field — but Constraints forbids editing other nodes, so
@@ -840,8 +843,7 @@ def _done_when(
 
     if symptom_event is not None and symptom_event.exception:
         conds.append(
-            f"`{symptom_event.node_name}` no longer fails with "
-            f"{label(symptom_event.exception)}."
+            f"`{symptom_event.node_name}` no longer fails with {label(symptom_event.exception)}."
         )
 
     if not conds:
@@ -1059,9 +1061,9 @@ def _causal_section(
     symptom_path, symptom_note = _resolve_source(record, symptom, source_cache)
     where = f"`{symptom_path}`" if symptom_path else f"the `{symptom}` node"
 
-    chain = record.root_cause_chain or []
-    if len(chain) > 1 and target in chain and symptom in chain:
-        narrative = " → ".join(f"`{n}`" for n in chain)
+    path = _propagation_nodes(record, target)
+    if len(path) > 1 and target in path and symptom in path:
+        narrative = " → ".join(f"`{n}`" for n in path)
         out.append(
             f"The failure surfaced in {where}, but that is not the bug. It "
             f"propagated: {narrative}."
@@ -1092,9 +1094,7 @@ def _constraints(
     symptom_event: Optional[NodeEvent],
 ) -> list[str]:
     lines = [f"- Change only the `{target}` node's function."]
-    lines.append(
-        "- Do not change the pipeline's state schema, key names, or the graph wiring."
-    )
+    lines.append("- Do not change the pipeline's state schema, key names, or the graph wiring.")
     lines.append("- Do not edit other node functions.")
     if symptom_event is not None:
         lines.append(

--- a/tests/test_fix_prompt.py
+++ b/tests/test_fix_prompt.py
@@ -17,9 +17,12 @@ from argus.fix_prompt import (
 )
 from argus.models import (
     AnomalySignal,
+    CorrelationReport,
+    DegradationOrigin,
     FieldMismatch,
     InspectionResult,
     NodeEvent,
+    PropagationChain,
     RunRecord,
     SemanticSignal,
     ToolFailure,
@@ -284,6 +287,161 @@ def test_degraded_cascade_targets_origin_not_crash_site(project: Path) -> None:
     assert "rate-limited" in result.prompt
 
 
+def test_ranked_origins_are_not_treated_as_a_propagation_path(project: Path) -> None:
+    """After correlation, root_cause_chain is confidence-ranked onsets.
+
+    The last name is another independent onset, not the crash site — using
+    it as the symptom (or joining the list with →) invents a cascade.
+    """
+    record = _record(
+        overall_status="silent_failure",
+        first_failure_step="retrieve",
+        root_cause_chain=["retrieve", "summarize"],
+        node_fn_paths={"retrieve": "src/nodes/retrieval.py:1"},
+        correlation=CorrelationReport(
+            run_id="a1b2c3d4e5f6",
+            degradation_origins=[
+                DegradationOrigin(
+                    node_name="retrieve",
+                    step_index=0,
+                    signal_types=("tool_failure",),
+                    confidence=0.95,
+                    reason="empty docs",
+                ),
+                DegradationOrigin(
+                    node_name="summarize",
+                    step_index=1,
+                    signal_types=("semantic_fail",),
+                    confidence=0.85,
+                    reason="placeholder summary",
+                ),
+            ],
+            propagation_chains=[],
+            causal_summary="Two independent onsets.",
+            timeline=[],
+        ),
+        steps=[
+            _event(
+                0,
+                "retrieve",
+                "fail",
+                output_dict={"docs": []},
+                inspection=_inspection(
+                    empty_fields=["docs"],
+                    has_tool_failure=True,
+                    tool_failures=[
+                        ToolFailure(
+                            failure_type="empty_result",
+                            field_name="docs",
+                            severity="critical",
+                            evidence="no hits",
+                        )
+                    ],
+                    message="empty docs",
+                ),
+            ),
+            _event(
+                1,
+                "summarize",
+                "semantic_fail",
+                output_dict={"summary": "lorem ipsum"},
+                inspection=_inspection(message="placeholder"),
+            ),
+            _event(2, "classify", "pass", output_dict={"label": "ok"}),
+        ],
+    )
+    result = build_fix_prompt_for_record(record)
+
+    assert result.node == "retrieve"
+    assert "It propagated:" not in result.prompt
+    assert "**Do not edit `summarize`.**" not in result.prompt
+    assert "## Why this file and not the crash site" not in result.prompt
+
+
+def test_low_confidence_origins_keep_the_inspector_path(project: Path) -> None:
+    """session.py only overwrites the chain at confidence >= 0.8.
+
+    Below that the inspector walk is still the path, even if the origin
+    names happen to match — do not drop the → narrative.
+    """
+    record = _cascade_record()
+    record.correlation = CorrelationReport(
+        run_id=record.run_id,
+        degradation_origins=[
+            DegradationOrigin(
+                node_name="retrieve",
+                step_index=0,
+                signal_types=("tool_failure",),
+                confidence=0.79,
+                reason="maybe retrieve",
+            ),
+            DegradationOrigin(
+                node_name="summarize",
+                step_index=1,
+                signal_types=("tool_failure",),
+                confidence=0.6,
+                reason="maybe summarize",
+            ),
+            DegradationOrigin(
+                node_name="classify",
+                step_index=2,
+                signal_types=("tool_failure",),
+                confidence=0.5,
+                reason="maybe classify",
+            ),
+        ],
+        propagation_chains=[],
+        causal_summary="Low confidence — inspector walk stands.",
+        timeline=[],
+    )
+    result = build_fix_prompt_for_record(record)
+
+    assert result.node == "retrieve"
+    assert "`retrieve` → `summarize` → `classify`" in result.prompt
+
+
+def test_ranked_origins_use_recorded_propagation_chain(project: Path) -> None:
+    """When correlation overwrote the chain, a real propagation_chains
+    entry is the path to narrate — not the ranked origin list."""
+    record = _cascade_record()
+    record.root_cause_chain = ["retrieve", "summarize"]
+    record.first_failure_step = "retrieve"
+    record.correlation = CorrelationReport(
+        run_id=record.run_id,
+        degradation_origins=[
+            DegradationOrigin(
+                node_name="retrieve",
+                step_index=0,
+                signal_types=("tool_failure",),
+                confidence=0.95,
+                reason="rate limited",
+            ),
+            DegradationOrigin(
+                node_name="summarize",
+                step_index=1,
+                signal_types=("tool_failure",),
+                confidence=0.82,
+                reason="empty docs",
+            ),
+        ],
+        propagation_chains=[
+            PropagationChain(
+                chain_type="tool_failure_cascade",
+                nodes=("retrieve", "summarize", "classify"),
+                links=(),
+                summary="empty docs cascaded into the classifier",
+            )
+        ],
+        causal_summary="Rate limit at retrieve cascaded to classify.",
+        timeline=[],
+    )
+    result = build_fix_prompt_for_record(record)
+
+    assert result.node == "retrieve"
+    assert "**Do not edit `classify`.**" in result.prompt
+    assert "`retrieve` → `summarize` → `classify`" in result.prompt
+
+
 def test_causal_section_never_exonerates_the_true_root_cause(project: Path) -> None:
     """--node overriding to a downstream node must not certify an upstream
     node (possibly the real bug) as 'behaving correctly'."""
@@ -446,9 +604,7 @@ def test_windows_drive_letter_path_is_not_mistaken_for_a_missing_colon(
         overall_status="crashed",
         first_failure_step="retrieve",
         root_cause_chain=["retrieve"],
-        node_fn_paths={
-            "retrieve": str(project / "src" / "nodes" / "retrieval.py") + ":1"
-        },
+        node_fn_paths={"retrieve": str(project / "src" / "nodes" / "retrieval.py") + ":1"},
         steps=[
             _event(0, "retrieve", "crashed", output_dict=None, exception="RuntimeError: boom"),
         ],
@@ -634,8 +790,7 @@ def test_sanitized_does_not_leak_exception_message(project: Path) -> None:
                 "crashed",
                 output_dict=None,
                 exception=(
-                    "Traceback (most recent call last):\n"
-                    "KeyError: 'customer_ssn=123-45-6789'"
+                    "Traceback (most recent call last):\nKeyError: 'customer_ssn=123-45-6789'"
                 ),
             )
         ],
@@ -647,6 +802,9 @@ def test_sanitized_does_not_leak_exception_message(project: Path) -> None:
     assert "KeyError" in scrubbed
     # The section's own claim must now actually be true.
     assert "Values omitted" in scrubbed
+    # --sanitized omits the traceback; do not promise one is below.
+    assert "traceback is below" not in scrubbed.lower()
+    assert "exception type is below" in scrubbed.lower()
 
 
 def test_sanitized_does_not_leak_multiline_exception_message(project: Path) -> None:
@@ -906,10 +1064,7 @@ def test_node_override_on_healthy_node_raises(project: Path) -> None:
 
 def test_prompt_is_deterministic(project: Path) -> None:
     record = _cascade_record()
-    assert (
-        build_fix_prompt_for_record(record).prompt
-        == build_fix_prompt_for_record(record).prompt
-    )
+    assert build_fix_prompt_for_record(record).prompt == build_fix_prompt_for_record(record).prompt
 
 
 def test_no_internal_jargon_leaks(project: Path) -> None:
@@ -995,8 +1150,7 @@ def _rogue_blocks(prompt: str) -> list[str]:
     return [
         line
         for line in _outside_fences(prompt).splitlines()
-        if line.lstrip().startswith(("#", ">"))
-        and not line.startswith(_OUR_HEADINGS)
+        if line.lstrip().startswith(("#", ">")) and not line.startswith(_OUR_HEADINGS)
     ]
 
 
@@ -1119,9 +1273,7 @@ def test_cli_writes_prompt_to_file(project: Path) -> None:
 
 def test_cli_node_and_sanitized_flags(project: Path) -> None:
     save_run(_cascade_record())
-    result = CliRunner().invoke(
-        app, ["fix", "a1b2c3d4", "--node", "classify", "--sanitized"]
-    )
+    result = CliRunner().invoke(app, ["fix", "a1b2c3d4", "--node", "classify", "--sanitized"])
     assert result.exit_code == 0
     assert "Q3 revenue breakdown" not in result.stdout
 


### PR DESCRIPTION
## Summary
- PR #15 (`argus fix`) is already on master. Cursor Bugbot reviewed it after merge and left two findings that never landed.
- Stop treating `root_cause_chain` as an origin→symptom path when correlation has replaced it with confidence-ranked `degradation_origins`. Use a recorded `propagation_chains` entry instead, and keep the inspector walk when confidence is below 0.8.
- Under `--sanitized`, do not say the traceback is below — evidence only prints the exception type.

## Test plan
- [x] `pytest tests/test_fix_prompt.py` (45 passed)
- [ ] Confirm a persisted run with high-confidence origins no longer invents `a → b → c` from the ranked list
- [ ] Confirm `argus fix <run> --sanitized` on a crash does not mention a traceback


Made with [Cursor](https://cursor.com)