### PR TITLE
Reject verbatim-echo signatures in signature_generalizer's LLM path

### DIFF
--- a/src/argus/signature_generalizer.py
+++ b/src/argus/signature_generalizer.py
@@ -239,6 +239,8 @@ def _llm_generalize(
             regex = regex[6:].strip()
         if not regex:
             return None  # empty pattern would match every output
+        if regex.strip().lower() == pattern.strip().lower():
+            return None  # echoed the input verbatim — heuristic may do better
 
         # Validate it compiles
         compiled = re.compile(regex, re.IGNORECASE)

--- a/tests/test_signature_generalizer.py
+++ b/tests/test_signature_generalizer.py
@@ -274,6 +274,57 @@ def test_llm_generalize_rejects_missing_choices(monkeypatch):
 
 
 @pytest.mark.unit
+def test_llm_generalize_rejects_verbatim_echo(monkeypatch):
+    """A model that echoes the input literal back has generalized nothing.
+
+    Both compile and evidence checks let an echo through — it's a valid
+    regex and it trivially matches its own evidence. Left uncaught, the
+    literal gets stored as `generalized=True` with metacharacters now live:
+    a period in the original text starts matching any character instead of
+    itself, so the "generalized" signature is quietly broader than the
+    string it came from.
+    """
+    _mock_llm(monkeypatch, "rate limit exceeded")
+    assert _llm_generalize("rate limit exceeded", ("rate limit exceeded",)) is None
+
+
+@pytest.mark.unit
+def test_llm_generalize_rejects_echo_regardless_of_case_or_padding(monkeypatch):
+    """The echo check is case-insensitive and ignores surrounding whitespace.
+
+    A model that changes only case or adds stray whitespace has still
+    generalized nothing — it should be rejected the same as a byte-identical
+    echo, not accepted because the strings don't compare equal literally.
+    """
+    _mock_llm(monkeypatch, "  Rate Limit Exceeded  ")
+    assert _llm_generalize("rate limit exceeded", ("rate limit exceeded",)) is None
+
+
+@pytest.mark.unit
+def test_llm_generalize_accepts_genuine_generalization(monkeypatch):
+    """The echo guard must not reject real generalization along with it."""
+    _mock_llm(monkeypatch, r"rate\s+limit\s+(?:exceeded|reached)")
+    result = _llm_generalize("rate limit exceeded", ("rate limit exceeded",))
+    assert result == r"rate\s+limit\s+(?:exceeded|reached)"
+
+
+@pytest.mark.unit
+def test_generalize_signature_falls_back_to_heuristic_on_echo(monkeypatch):
+    """End to end: an echoed pattern must not be stored as if generalized.
+
+    Before the guard, this path stored the literal pattern as a regex with
+    generalized=True — true in name only, since nothing was generalized and
+    the pattern's own metacharacters (if any) were now live. The heuristic
+    fallback is a real generalization instead of a no-op wearing one.
+    """
+    _mock_llm(monkeypatch, "I cannot provide financial advice")
+    result = generalize_signature(_make_sig())
+    assert result.pattern != "I cannot provide financial advice"
+    compiled = re.compile(result.pattern, re.IGNORECASE)
+    assert compiled.search("unable to offer investment guidance")
+
+
+@pytest.mark.unit
 def test_generalize_signature_prefers_the_llm_regex(monkeypatch):
     """End to end: an LLM pattern wins over the heuristic one."""
     _mock_llm(monkeypatch, r"(?:cannot|unable\s+to)\s+\S+\s+financial\s+advice")


### PR DESCRIPTION
## What & why

On #18's thread, [I probed](https://github.com/VaradDurge/ARGUS/pull/18#issuecomment-5313150853) which prose shapes survive `_llm_generalize`'s two validation checks (compiles, matches its own evidence). Five rejected cleanly. One didn't: **a model that echoes the input pattern verbatim.**

An echo is a valid regex — it compiles, and it trivially matches the evidence it was built from — so it passed both checks while generalizing nothing. That's not harmless: the string is now *compiled* as a regex where it used to be matched as a `contains_ci` literal, so any regex metacharacter already in it changes meaning. A period starts matching any character instead of itself. The stored signature ends up quietly broader than the literal it came from, filed as `generalized=True`.

[Varad confirmed](https://github.com/VaradDurge/ARGUS/pull/18#issuecomment-5313203612) and asked for the guard to ship — originally as a same-PR addition to #18, but #18 merged before this was ready, so it lands here instead.

## The fix

One check next to the existing empty-pattern guard in `_llm_generalize`:

```python
if regex.strip().lower() == pattern.strip().lower():
    return None  # echoed the input verbatim — heuristic may do better
```

Case-insensitive and whitespace-tolerant, matching how the rest of the function already normalizes the model's answer. On rejection, `generalize_signature` falls through to `_heuristic_generalize`, which does real work on the same input instead of storing a no-op as a success.

**Ownership, to be precise:** both validation checks are pre-existing and unchanged by this PR. #18 didn't introduce the gap — it put Gemini and Claude users on this LLM path for the first time, on the cheap tier, which is where an echo is more likely than on GPT-4o-class models. That's what made it worth closing now rather than later.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / internal
- [ ] Docs
- [ ] Other:

## Checklist

- [x] I have read the [Contributing guide](../CONTRIBUTING.md).
- [x] I have signed the [CLA](../CLA.md) (the bot will prompt on first PR).
- [x] My change targets the **open-source core** only — I have **not** modified `cloud/` or `supabase/` (proprietary; maintainer-only).
- [x] Tests added/updated and `pytest` passes locally. *(651 passed, 3 skipped, 2 xfailed — 4 new tests: verbatim echo rejected, echo rejected regardless of case/padding, genuine generalization still accepted, end-to-end fallback to heuristic on echo.)*
- [x] `ruff check .` passes.
- [x] Docs updated if behavior or the public API changed. *(No public API or documented behavior changed — internal fail-open path only.)*

## Notes for reviewers

Verified against the exact case from the #18 thread: `_llm_generalize("rate limit 5.0 exceeded", ("rate limit 5.0 exceeded",))` — which previously returned the literal as an "accepted" regex that also matched `"rate limit 5X0 exceeded"` via the widened `.` — now returns `None` and falls back to the heuristic.

**Left out, per the same thread:** a live run against a non-OpenAI model (Gemini/Claude). Varad flagged it as low-priority and not a blocker — everything in both the original probe and this fix was checked against the validation path with mocks, not observed traffic, since this environment has no Gemini/Anthropic keys.

**Blast radius:** one function, `argus.signature_generalizer._llm_generalize`. No callers change signature; behavior changes only for the specific case of the model echoing its input, which previously slipped through as a false "generalized."

---
_Generated by [Claude Code](https://claude.ai/code/session_01NKEqHmpj6rCdhj2F8KdTJR)_