### PR TITLE
feat: Phase 1 — Time-Travel State Patching (steps 1.1–1.4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,33 @@ argus diff <rerun-id>                 # compare vs original
 
 External API calls (OpenAI, etc.) are recorded by default — replays are free and deterministic.
 
+### Time-Travel: edit the state, then resume
+
+Spotted the bad value? Fix it in the saved state and resume from there — no code change, no re-running the steps that already worked:
+
+```bash
+argus replay <run-id> node_7 --set status=OK          # correct a value
+argus replay <run-id> node_7 --delete stale_field     # reproduce a dropped field
+argus replay <run-id> node_7 --patch fix.json         # a full patch document
+argus replay <run-id> node_7 --set status=OK --dry-run  # preview, run nothing
+```
+
+Upstream nodes stay frozen, so only the resumed trajectory changes. Paths are dotted with list
+indices — `items[0].name` — and match the `field_path` ARGUS reports on a failing signal, so you
+can paste one straight in. A patch file takes the same three ops:
+
+```json
+{
+  "delete": ["broken_field"],
+  "set":    {"query": "fixed query", "meta.retries": 0},
+  "merge":  {"config": {"temperature": 0}}
+}
+```
+
+Patches are strict by default: a mistyped path errors with a "did you mean" hint instead of
+silently adding a field (use `--create-missing` to add new keys). Every patched replay records
+the patch it ran with, so the run explains its own divergence from the original.
+
 ---
 
 ## Semantic Judge

--- a/src/argus/cli/cmd_open_ui.py
+++ b/src/argus/cli/cmd_open_ui.py
@@ -11,6 +11,7 @@ import uuid
 import webbrowser
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
+from typing import Any
 from urllib.parse import parse_qs, unquote, urlparse
 
 from rich.console import Console
@@ -487,20 +488,33 @@ def _run_replay_worker(
     from_node: str,
     app_module_str: str | None,
     mode: str = "full",
+    patch: dict[str, Any] | None = None,
+    create_missing: bool = False,
 ) -> None:
-    """Background thread: runs ReplayEngine and updates _replay_jobs on completion."""
+    """Background thread: runs ReplayEngine and updates _replay_jobs on completion.
+
+    The optional *patch* edits the replayed node's recorded input state before
+    execution; it is validated by the request handler before this thread starts.
+    """
     from argus.replay import ReplayEngine  # noqa: PLC0415
 
     try:
         engine = ReplayEngine()
         if mode == "node":
-            new_run_id = engine.replay_node(run_id=run_id, node_name=from_node)
+            new_run_id = engine.replay_node(
+                run_id=run_id,
+                node_name=from_node,
+                patch=patch,
+                create_missing=create_missing,
+            )
         else:
             factory = _import_factory_for_ui(app_module_str) if app_module_str else None
             new_run_id = engine.replay(
                 run_id=run_id,
                 from_node=from_node,
                 app_factory=factory,
+                patch=patch,
+                create_missing=create_missing,
             )
         with _replay_lock:
             _replay_jobs[job_id] = {"status": "done", "run_id": new_run_id, "error": None}
@@ -1056,13 +1070,72 @@ def _make_handler(
                             )
                             return
 
+                # Validate the optional state patch up front. A patch that fails
+                # inside the worker thread would surface only as a generic job
+                # error, losing the "did you mean" hint that makes it fixable.
+                patch = data.get("patch")
+                create_missing = bool(data.get("create_missing", False))
+                if patch is not None:
+                    from argus.state_patch import (  # noqa: PLC0415
+                        PatchError,
+                        preview_patch,
+                        validate_patch,
+                    )
+
+                    if not isinstance(patch, dict):
+                        self._send_json(
+                            {
+                                "error": "invalid_patch",
+                                "message": "patch must be a JSON object, got "
+                                f"{type(patch).__name__}",
+                            },
+                            400,
+                        )
+                        return
+
+                    target = next(
+                        (s for s in run_record.steps if s.node_name == from_step), None
+                    )
+                    if target is None:
+                        available = [s.node_name for s in run_record.steps]
+                        self._send_json(
+                            {
+                                "error": "unknown_node",
+                                "message": f"node '{from_step}' not found in run. "
+                                f"Available: {', '.join(available)}",
+                            },
+                            404,
+                        )
+                        return
+
+                    try:
+                        validate_patch(patch)
+                        # Dry-run against the real recorded state so a bad path is
+                        # rejected here rather than after the job is accepted.
+                        preview_patch(
+                            target.input_state, patch, create_missing=create_missing
+                        )
+                    except PatchError as exc:
+                        self._send_json(
+                            {"error": "invalid_patch", "message": str(exc)}, 400
+                        )
+                        return
+
                 job_id = str(uuid.uuid4())
                 with _replay_lock:
                     _replay_jobs[job_id] = {"status": "running", "run_id": None, "error": None}
 
                 t = threading.Thread(
                     target=_run_replay_worker,
-                    args=(job_id, run_id, from_step, effective_app, replay_mode),
+                    args=(
+                        job_id,
+                        run_id,
+                        from_step,
+                        effective_app,
+                        replay_mode,
+                        patch,
+                        create_missing,
+                    ),
                     daemon=True,
                 )
                 t.start()

--- a/src/argus/cli/cmd_open_ui.py
+++ b/src/argus/cli/cmd_open_ui.py
@@ -482,6 +482,99 @@ def _import_factory_for_ui(spec: str):
     return fn
 
 
+_MAX_PREVIEW_VALUE_CHARS = 2000
+
+
+class _PatchRequestError(Exception):
+    """A patch request that must be rejected, carrying its wire response."""
+
+    def __init__(self, error: str, message: str, status: int) -> None:
+        super().__init__(message)
+        self.error = error
+        self.message = message
+        self.status = status
+
+    def as_response(self) -> tuple[dict[str, str], int]:
+        return {"error": self.error, "message": self.message}, self.status
+
+
+def _resolve_patch_preview(
+    run_record: Any,
+    from_step: str,
+    patch: Any,
+    create_missing: bool,
+) -> list[Any]:
+    """Validate a patch against a run's recorded state and return its changes.
+
+    Shared by ``/api/replay`` — which discards the result and only wants the
+    validation — and ``/api/replay/preview``, which returns it. One code path
+    means a preview can never report a patch as valid that the real replay
+    would then reject.
+    """
+    from argus.state_patch import (  # noqa: PLC0415
+        PatchError,
+        preview_patch,
+        validate_patch,
+    )
+
+    if not isinstance(patch, dict):
+        raise _PatchRequestError(
+            "invalid_patch",
+            f"patch must be a JSON object, got {type(patch).__name__}",
+            400,
+        )
+
+    target = next((s for s in run_record.steps if s.node_name == from_step), None)
+    if target is None:
+        available = [s.node_name for s in run_record.steps]
+        raise _PatchRequestError(
+            "unknown_node",
+            f"node '{from_step}' not found in run. Available: {', '.join(available)}",
+            404,
+        )
+
+    try:
+        validate_patch(patch)
+        # Dry-run against the real recorded state so a bad path is rejected
+        # before anything is executed or enqueued.
+        return preview_patch(target.input_state, patch, create_missing=create_missing)
+    except PatchError as exc:
+        raise _PatchRequestError("invalid_patch", str(exc), 400) from exc
+
+
+def _cap_preview_value(value: Any) -> Any:
+    """Cap one preview value so a large state subtree cannot flood the response.
+
+    The editor calls the preview endpoint on every pause in typing, so an
+    uncapped before/after would ship whole state trees per keystroke.
+    """
+    try:
+        text = json.dumps(value, default=str, ensure_ascii=False)
+    except Exception:
+        text = str(value)
+    if len(text) <= _MAX_PREVIEW_VALUE_CHARS:
+        return value
+    return {
+        "__argus_truncated__": True,
+        "preview": text[:_MAX_PREVIEW_VALUE_CHARS],
+        "full_length": len(text),
+    }
+
+
+def _serialize_patch_changes(changes: list[Any]) -> list[dict[str, Any]]:
+    """Render PatchChange records for the wire, with values capped."""
+    return [
+        {
+            "op": c.op,
+            "path": c.path,
+            "before": _cap_preview_value(c.before),
+            "after": _cap_preview_value(c.after),
+            "existed": c.existed,
+        }
+        for c in changes
+    ]
+
+
 def _run_replay_worker(
     job_id: str,
     run_id: str,
@@ -1076,49 +1169,13 @@ def _make_handler(
                 patch = data.get("patch")
                 create_missing = bool(data.get("create_missing", False))
                 if patch is not None:
-                    from argus.state_patch import (  # noqa: PLC0415
-                        PatchError,
-                        preview_patch,
-                        validate_patch,
-                    )
-
-                    if not isinstance(patch, dict):
-                        self._send_json(
-                            {
-                                "error": "invalid_patch",
-                                "message": "patch must be a JSON object, got "
-                                f"{type(patch).__name__}",
-                            },
-                            400,
-                        )
-                        return
-
-                    target = next(
-                        (s for s in run_record.steps if s.node_name == from_step), None
-                    )
-                    if target is None:
-                        available = [s.node_name for s in run_record.steps]
-                        self._send_json(
-                            {
-                                "error": "unknown_node",
-                                "message": f"node '{from_step}' not found in run. "
-                                f"Available: {', '.join(available)}",
-                            },
-                            404,
-                        )
-                        return
-
                     try:
-                        validate_patch(patch)
-                        # Dry-run against the real recorded state so a bad path is
-                        # rejected here rather than after the job is accepted.
-                        preview_patch(
-                            target.input_state, patch, create_missing=create_missing
+                        _resolve_patch_preview(
+                            run_record, from_step, patch, create_missing
                         )
-                    except PatchError as exc:
-                        self._send_json(
-                            {"error": "invalid_patch", "message": str(exc)}, 400
-                        )
+                    except _PatchRequestError as exc:
+                        err_body, err_status = exc.as_response()
+                        self._send_json(err_body, err_status)
                         return
 
                 job_id = str(uuid.uuid4())
@@ -1141,6 +1198,55 @@ def _make_handler(
                 t.start()
 
                 self._send_json({"job_id": job_id}, 202)
+            elif path == "/api/replay/preview":
+                # Answers "what would this patch change?" without running
+                # anything — no job is started and no run is written.
+                length = int(self.headers.get("Content-Length", 0))
+                body = self.rfile.read(length)
+                try:
+                    data = json.loads(body)
+                except Exception:
+                    self._send_json({"error": "invalid JSON"}, 400)
+                    return
+
+                run_id = (data.get("run_id") or "").strip()
+                from_step = (data.get("from_step") or "").strip()
+                if not run_id or not from_step:
+                    self._send_json({"error": "run_id and from_step are required"}, 400)
+                    return
+
+                if "patch" not in data:
+                    self._send_json({"error": "patch is required"}, 400)
+                    return
+
+                from argus.storage import load_run as _load_run  # noqa: PLC0415
+
+                try:
+                    run_record = _load_run(run_id)
+                except (FileNotFoundError, ValueError):
+                    self._send_json({"error": "run not found"}, 404)
+                    return
+
+                try:
+                    changes = _resolve_patch_preview(
+                        run_record,
+                        from_step,
+                        data.get("patch"),
+                        bool(data.get("create_missing", False)),
+                    )
+                except _PatchRequestError as exc:
+                    err_body, err_status = exc.as_response()
+                    self._send_json(err_body, err_status)
+                    return
+
+                from argus.state_patch import format_changes  # noqa: PLC0415
+
+                self._send_json(
+                    {
+                        "changes": _serialize_patch_changes(changes),
+                        "summary": format_changes(changes),
+                    }
+                )
             elif path.startswith("/api/feedback/") and path.endswith("/resolve"):
                 fb_id = path[len("/api/feedback/") : -len("/resolve")]
                 length = int(self.headers.get("Content-Length", 0))

--- a/src/argus/cli/cmd_replay.py
+++ b/src/argus/cli/cmd_replay.py
@@ -12,9 +12,117 @@ from rich.text import Text
 from argus.cli import print_footer
 from argus.models import RunRecord
 from argus.replay import ReplayEngine
+from argus.state_patch import PatchError, format_changes, preview_patch
 from argus.storage import load_run
 
 console = Console()
+
+
+def _parse_set_value(raw: str) -> Any:
+    """Parse a --set value as JSON, falling back to a plain string.
+
+    ``retries=0`` yields the integer 0 and ``ok=true`` yields True, while
+    ``query=hello`` stays a string.  Wrap in quotes to force a string:
+    ``--set flag='"true"'``.
+    """
+    import json
+
+    try:
+        return json.loads(raw)
+    except ValueError:
+        return raw
+
+
+def build_patch(
+    patch_file: str | None,
+    set_pairs: list[str] | None,
+    delete_paths: list[str] | None,
+) -> dict[str, Any] | None:
+    """Assemble a patch document from CLI options. Returns None if empty.
+
+    A ``--patch`` file provides the base; ``--set`` and ``--delete`` are
+    layered on top, so a flag overrides the same path in the file.
+    """
+    import json
+
+    patch: dict[str, Any] = {}
+
+    if patch_file:
+        path = Path(patch_file)
+        if not path.exists():
+            raise PatchError(f"patch file not found: {patch_file}")
+        try:
+            loaded = json.loads(path.read_text(encoding="utf-8"))
+        except ValueError as exc:
+            raise PatchError(f"patch file {patch_file} is not valid JSON: {exc}") from exc
+        if not isinstance(loaded, dict):
+            raise PatchError(
+                f"patch file {patch_file} must contain a JSON object, "
+                f"got {type(loaded).__name__}"
+            )
+        patch = loaded
+
+    for pair in set_pairs or []:
+        if "=" not in pair:
+            raise PatchError(
+                f"invalid --set {pair!r} — expected 'path=value' "
+                "(e.g. --set meta.retries=0)"
+            )
+        raw_path, _, raw_value = pair.partition("=")
+        raw_path = raw_path.strip()
+        if not raw_path:
+            raise PatchError(f"invalid --set {pair!r} — the path is empty")
+        patch.setdefault("set", {})
+        if not isinstance(patch["set"], dict):
+            raise PatchError("patch file's 'set' op must be an object to combine with --set")
+        patch["set"][raw_path] = _parse_set_value(raw_value)
+
+    for raw_path in delete_paths or []:
+        existing = patch.get("delete")
+        if existing is None:
+            patch["delete"] = [raw_path]
+        elif isinstance(existing, str):
+            patch["delete"] = [existing, raw_path]
+        elif isinstance(existing, list):
+            existing.append(raw_path)
+        else:
+            raise PatchError(
+                "patch file's 'delete' op must be a list to combine with --delete"
+            )
+
+    return patch or None
+
+
+def _print_patch_preview(
+    record: RunRecord,
+    from_step: str,
+    patch: dict[str, Any],
+    create_missing: bool,
+) -> bool:
+    """Show what the patch changes. Returns False if it cannot be applied."""
+    step = next((e for e in record.steps if e.node_name == from_step), None)
+    if step is None:  # pragma: no cover - caller validates first
+        return False
+
+    try:
+        changes = preview_patch(step.input_state, patch, create_missing=create_missing)
+    except PatchError as exc:
+        console.print()
+        console.print(f"  [red]patch error:[/red] {exc}")
+        console.print()
+        return False
+
+    console.print()
+    console.print(Text("  state patch", style="bold italic"))
+    console.print()
+    if not changes:
+        console.print("  [dim]patch is empty — nothing to change[/dim]")
+    for line in format_changes(changes):
+        marker, _, rest = line.partition(" ")
+        style = {"+": "green", "-": "red", "~": "yellow"}.get(marker, "dim")
+        console.print(f"  [bold {style}]{marker}[/bold {style}] {rest}")
+    console.print()
+    return True
 
 
 def replay_run(
@@ -22,6 +130,9 @@ def replay_run(
     from_step: str,
     app_module_str: str | None,
     only: bool = False,
+    patch: dict[str, Any] | None = None,
+    create_missing: bool = False,
+    dry_run: bool = False,
 ) -> None:
     try:
         record = load_run(run_id)
@@ -73,6 +184,8 @@ def replay_run(
     header.append(from_step, style="bold")
     if only:
         header.append("  (isolated)", style="italic dim")
+    if patch is not None:
+        header.append("  + patch", style="italic yellow")
     console.print(f"  {header}")
     console.print()
     console.print(Rule(style="dim"))
@@ -86,6 +199,21 @@ def replay_run(
             f"  [dim]Re-running from [bold]{from_step}[/bold] "
             f"— upstream outputs frozen from [bold]{run_id}[/bold][/dim]"
         )
+    # ── State patch preview ───────────────────────────────────────────────
+    if patch is not None:
+        if not _print_patch_preview(record, from_step, patch, create_missing):
+            return
+        if dry_run:
+            console.print("  [dim]dry run — nothing was executed[/dim]")
+            console.print()
+            print_footer()
+            return
+    elif dry_run:
+        console.print("  [dim]dry run — no patch given, nothing to preview[/dim]")
+        console.print()
+        print_footer()
+        return
+
     # Warn about non-deterministic external calls
     console.print()
     console.print(
@@ -102,12 +230,16 @@ def replay_run(
             new_run_id = engine.replay_node(
                 run_id=run_id,
                 node_name=from_step,
+                patch=patch,
+                create_missing=create_missing,
             )
         else:
             new_run_id = engine.replay(
                 run_id=run_id,
                 from_node=from_step,
                 app_factory=factory,
+                patch=patch,
+                create_missing=create_missing,
             )
     except Exception as e:
         console.print(f"[red]Replay failed:[/red] {e}")

--- a/src/argus/cli/main.py
+++ b/src/argus/cli/main.py
@@ -54,6 +54,7 @@ _COMMANDS = [
     ("show run <id>", "inspect a specific run  (full id or 8-char prefix)"),
     ("replay <id> <node>", "re-run from a saved node checkpoint"),
     ("replay <id> <node> --only", "re-run just that node in isolation"),
+    ("replay <id> <node> --set k=v", "edit the state, then resume from that node"),
     ("replay <id> <node> --app mod:fn", "replay with a live graph factory"),
     ("inspect <id> --step <node>", "dump raw input / output state for a node"),
     ("diff <id>", "diff a replay run against its original"),
@@ -70,6 +71,7 @@ _WHEN_TO_USE = [
     ("list", "after a run — get the run id for further commands"),
     ("show", "understand what happened: statuses, warnings, root cause"),
     ("replay", "re-run from a broken node after fixing the code (warns about live calls)"),
+    ("replay --set", "fix a bad value in the saved state and resume — no code change"),
     ("inspect", "read exact input/output JSON for a specific step"),
     ("fix", "hand the root cause to a coding agent as a ready-made prompt"),
     ("diff", "verify a fix actually changed behaviour between runs"),
@@ -81,6 +83,11 @@ _OPTIONS = [
         "str",
         "zero-arg callable returning StateGraph or CompiledGraph",
     ),
+    ("replay  --set  path=value", "str", "patch a state value before replaying (repeatable)"),
+    ("replay  --delete  path", "str", "drop a state field before replaying (repeatable)"),
+    ("replay  --patch  file.json", "str", "state patch document to apply before replaying"),
+    ("replay  --dry-run", "flag", "show what the patch changes without executing"),
+    ("replay  --create-missing", "flag", "let the patch add keys that don't exist yet"),
     ("inspect --step / -s  <node>", "str", "node name to inspect  (required)"),
     ("show run <id>", "str", "full run id or 8-char prefix"),
     (
@@ -236,9 +243,61 @@ def cmd_replay(
             help="Re-run only the specified node in isolation (skip downstream).",
         ),
     ] = False,
+    patch: Annotated[
+        Optional[str],
+        typer.Option(
+            "--patch",
+            help="JSON file with a state patch to apply before replaying.",
+        ),
+    ] = None,
+    set_: Annotated[
+        Optional[list[str]],
+        typer.Option(
+            "--set",
+            help="Patch a value: 'path=value' (repeatable). e.g. --set meta.retries=0",
+        ),
+    ] = None,
+    delete: Annotated[
+        Optional[list[str]],
+        typer.Option(
+            "--delete",
+            help="Remove a field before replaying (repeatable). e.g. --delete docs",
+        ),
+    ] = None,
+    create_missing: Annotated[
+        bool,
+        typer.Option(
+            "--create-missing",
+            help="Allow the patch to add keys that don't exist yet.",
+        ),
+    ] = False,
+    dry_run: Annotated[
+        bool,
+        typer.Option(
+            "--dry-run",
+            help="Show what the patch changes without running anything.",
+        ),
+    ] = False,
 ) -> None:
-    """Re-run a pipeline from a saved step using stored input state."""
-    replay_run(run_id=run_id, from_step=from_step, app_module_str=app, only=only)
+    """Re-run a pipeline from a saved step, optionally patching its state first."""
+    from argus.cli.cmd_replay import build_patch
+    from argus.state_patch import PatchError
+
+    try:
+        patch_doc = build_patch(patch, set_, delete)
+    except PatchError as exc:
+        _console.print(f"[red]Error:[/red] {exc}")
+        raise typer.Exit(code=1) from None
+
+    replay_run(
+        run_id=run_id,
+        from_step=from_step,
+        app_module_str=app,
+        only=only,
+        patch=patch_doc,
+        create_missing=create_missing,
+        dry_run=dry_run,
+    )
 
 
 @app.command("inspect")

--- a/src/argus/models.py
+++ b/src/argus/models.py
@@ -243,6 +243,8 @@ class RunRecord:
     node_fn_paths: dict[str, str] | None = None  # {node_name: relative_file_path}
     interrupted: bool = False  # True if a GraphInterrupt occurred
     interrupt_node: str | None = None  # node name where interrupt occurred
+    # Patch applied to the replayed node's input state before this run (time-travel)
+    state_patch: dict[str, Any] | None = None
     total_llm_calls: int = 0
     total_tokens: int = 0
     total_cost_usd: float | None = None

--- a/src/argus/replay.py
+++ b/src/argus/replay.py
@@ -61,16 +61,50 @@ class ReplayEngine:
     def __init__(self, max_field_size: int = 50_000) -> None:
         self._max_field_size = max_field_size
 
+    @staticmethod
+    def _patch_input(
+        input_state: dict[str, Any],
+        patch: dict[str, Any] | None,
+        create_missing: bool,
+        node_name: str,
+    ) -> dict[str, Any]:
+        """Apply an optional state patch to a recorded input state.
+
+        Patching happens on the raw recorded dict *before* deserialization, so
+        typed states (pydantic / dataclass / TypedDict) are validated by the
+        deserializer against the patched values rather than bypassed.
+        """
+        if not patch:
+            return input_state
+        from argus.state_patch import PatchError, apply_patch
+
+        try:
+            return apply_patch(input_state, patch, create_missing=create_missing)
+        except PatchError as exc:
+            raise PatchError(
+                f"cannot patch input state for node '{node_name}': {exc}"
+            ) from exc
+
     def replay_node(
         self,
         run_id: str,
         node_name: str,
         state_type: type | None = None,
+        patch: dict[str, Any] | None = None,
+        create_missing: bool = False,
     ) -> str:
         """Re-execute a single node in isolation using its original input state.
 
         Imports the node function via stored node_fn_refs, runs it with the
         original input_state, and records a single-step RunRecord.
+
+        Args:
+            run_id: the run-id (or prefix) to replay from
+            node_name: the node to re-run
+            state_type: optional state type class for deserialization
+            patch: optional state patch applied to the node's recorded input
+                before replaying (see :mod:`argus.state_patch`)
+            create_missing: allow the patch to create keys that do not exist
 
         Returns:
             new run-id of the single-node replay run
@@ -95,7 +129,8 @@ class ReplayEngine:
                     "Re-record the run with the latest argus to enable single-node replay."
                 )
 
-        state = safe_deserialize(step.input_state, state_type)
+        raw_state = self._patch_input(step.input_state, patch, create_missing, node_name)
+        state = safe_deserialize(raw_state, state_type)
         fp = (record.node_fn_paths or {}).get(node_name)
         fn = _import_fn(record.node_fn_refs[node_name], file_path=fp)
 
@@ -107,6 +142,7 @@ class ReplayEngine:
         session.set_edges({})
         session.parent_run_id = record.run_id
         session.replay_from_step = node_name
+        session.state_patch = patch or None
         session.node_fn_refs = {node_name: record.node_fn_refs[node_name]}
 
         wrapped = session.wrap(node_name, fn)
@@ -121,6 +157,8 @@ class ReplayEngine:
         from_node: str,
         app_factory: Callable[[], Any] | None = None,
         state_type: type | None = None,
+        patch: dict[str, Any] | None = None,
+        create_missing: bool = False,
     ) -> str:
         """Replay a run starting from from_node.
 
@@ -129,6 +167,10 @@ class ReplayEngine:
             from_node: the node name to start replay from
             app_factory: optional — only needed if the run has no stored node_fn_refs
             state_type: optional state type class for deserialization
+            patch: optional state patch applied to from_node's recorded input
+                before replaying (see :mod:`argus.state_patch`).  Upstream
+                nodes stay frozen, so only the resumed trajectory changes.
+            create_missing: allow the patch to create keys that do not exist
 
         Returns:
             new run-id of the replay run
@@ -151,17 +193,18 @@ class ReplayEngine:
             if s.output_dict is not None:
                 frozen_map[s.node_name].append(s.output_dict)
 
-        # deserialize the input state
-        state = safe_deserialize(step.input_state, state_type)
+        # apply the optional patch to the raw recorded state, then deserialize
+        raw_state = self._patch_input(step.input_state, patch, create_missing, from_node)
+        state = safe_deserialize(raw_state, state_type)
 
         # Try factory-free replay first, fall back to factory mode
         if record.node_fn_refs:
-            return self._replay_direct(record, from_node, state, frozen_map)
+            return self._replay_direct(record, from_node, state, frozen_map, patch)
 
         # Auto-locate source files before requiring a factory
         record = self._auto_locate(record)
         if record.node_fn_refs:
-            return self._replay_direct(record, from_node, state, frozen_map)
+            return self._replay_direct(record, from_node, state, frozen_map, patch)
 
         if app_factory is not None:
             return self._replay_with_factory(
@@ -170,6 +213,7 @@ class ReplayEngine:
                 state,
                 frozen_map,
                 app_factory,
+                patch,
             )
 
         raise ValueError(
@@ -204,6 +248,7 @@ class ReplayEngine:
         from_node: str,
         state: Any,
         frozen_map: dict[str, list[Any]],
+        patch: dict[str, Any] | None = None,
     ) -> str:
         """Replay by importing node functions directly — no factory needed."""
         from argus.session import ArgusSession
@@ -233,6 +278,7 @@ class ReplayEngine:
         session.set_edges(record.graph_edge_map)
         session.parent_run_id = record.run_id
         session.replay_from_step = from_node
+        session.state_patch = patch or None
         session.frozen_outputs = dict(frozen_map)
         session.node_fn_refs = record.node_fn_refs
 
@@ -294,6 +340,7 @@ class ReplayEngine:
         state: Any,
         frozen_map: dict[str, list[Any]],
         app_factory: Callable[[], Any],
+        patch: dict[str, Any] | None = None,
     ) -> str:
         """Replay using a factory function (legacy fallback)."""
         from argus.watcher import ArgusWatcher
@@ -337,6 +384,7 @@ class ReplayEngine:
             if watcher._session is not None:
                 watcher._session.parent_run_id = record.run_id
                 watcher._session.replay_from_step = from_node
+                watcher._session.state_patch = patch or None
                 watcher._session.frozen_outputs = dict(frozen_map)
             new_run_id = watcher.run_id
             app = graph.compile()

--- a/src/argus/session.py
+++ b/src/argus/session.py
@@ -255,6 +255,8 @@ class ArgusSession:
         # set by ReplayEngine or ArgusWatcher for linked runs
         self.parent_run_id: str | None = parent_run_id
         self.replay_from_step: str | None = None
+        # patch applied to the replayed input state, recorded for provenance
+        self.state_patch: dict[str, Any] | None = None
 
         # frozen outputs for replay — maps node_name → list of saved output dicts (FIFO)
         self.frozen_outputs: dict[str, list[Any]] | None = None
@@ -1025,6 +1027,7 @@ class ArgusSession:
             node_fn_paths=self.node_fn_paths,
             parent_run_id=self.parent_run_id,
             replay_from_step=self.replay_from_step,
+            state_patch=self.state_patch,
             interrupted=has_interrupt,
             interrupt_node=interrupt_node,
             total_llm_calls=total_llm_calls,

--- a/src/argus/state_patch.py
+++ b/src/argus/state_patch.py
@@ -1,0 +1,550 @@
+"""State patching for time-travel replay.
+
+Replay re-runs a pipeline from a saved node using that node's recorded input
+state *verbatim*.  This module adds the missing half: editing that state
+before it is replayed, so a developer can fix a bad value at step 7 and
+resume the remaining steps — instead of fixing code and re-running all ten.
+
+A patch is a plain JSON document with up to three op groups::
+
+    {
+      "delete": ["broken_field", "meta.stale_token"],
+      "set":    {"query": "fixed query", "meta.retries": 0},
+      "merge":  {"config": {"temperature": 0}}
+    }
+
+Ops are applied in a fixed, documented order — **delete, then set, then
+merge** — so the result never depends on JSON key ordering.  A path that
+appears in more than one op group is rejected rather than silently resolved.
+
+Paths are dotted, with list indices in brackets.  Both ``items[0].name`` and
+``items.[0].name`` parse identically, so a ``field_path`` reported by a
+semantic signal can be pasted straight into a patch.
+
+Nothing here performs I/O or mutates its input: ``apply_patch`` deep-copies
+the state and returns a new dict.
+"""
+
+from __future__ import annotations
+
+import copy
+import difflib
+import re
+from dataclasses import dataclass
+from typing import Any, Union
+
+__all__ = [
+    "PatchChange",
+    "PatchError",
+    "apply_patch",
+    "format_changes",
+    "parse_path",
+    "preview_patch",
+    "validate_patch",
+]
+
+# Applied in this order regardless of key order in the patch document.
+_APPLY_ORDER = ("delete", "set", "merge")
+_VALID_OPS = frozenset(_APPLY_ORDER)
+
+_BRACKET_RE = re.compile(r"\[([^\[\]]*)\]")
+_MAX_KEYS_IN_ERROR = 10
+
+# A parsed path segment: a dict key (str) or a list index (int).
+Segment = Union[str, int]
+
+
+class PatchError(ValueError):
+    """Raised when a patch is malformed or cannot be applied to a state."""
+
+
+@dataclass(frozen=True)
+class PatchChange:
+    """A single value change produced by applying a patch."""
+
+    op: str  # "delete" | "set" | "merge"
+    path: str  # the path as written in the patch document
+    before: Any  # value before the change (None when it did not exist)
+    after: Any  # value after the change (None for deletes)
+    existed: bool  # whether the path resolved to an existing value
+
+
+# ── Path parsing ──────────────────────────────────────────────────────────────
+
+
+def parse_path(path: str) -> list[Segment]:
+    """Parse a dotted path into segments.
+
+    ``"items[0].name"`` and ``"items.[0].name"`` both yield
+    ``["items", 0, "name"]``.
+
+    Raises:
+        PatchError: if the path is empty or malformed.
+    """
+    if not isinstance(path, str):
+        raise PatchError(f"patch path must be a string, got {type(path).__name__}")
+    if not path.strip():
+        raise PatchError("patch path must be a non-empty string")
+
+    segments: list[Segment] = []
+    for raw in path.split("."):
+        if raw == "":
+            raise PatchError(
+                f"invalid path {path!r}: empty segment "
+                "(check for '..' or a leading/trailing '.')"
+            )
+        segments.extend(_parse_segment(raw, path))
+
+    if not segments:
+        raise PatchError(f"invalid path {path!r}: no segments found")
+    return segments
+
+
+def _parse_segment(raw: str, path: str) -> list[Segment]:
+    """Parse one dot-delimited chunk, e.g. ``items[0][1]`` or ``[3]`` or ``name``."""
+    bracket_at = raw.find("[")
+    if bracket_at == -1:
+        if "]" in raw:
+            raise PatchError(f"invalid path {path!r}: unmatched ']' in segment {raw!r}")
+        return [raw]
+
+    out: list[Segment] = []
+    name = raw[:bracket_at]
+    if name:
+        out.append(name)
+
+    pos = bracket_at
+    while pos < len(raw):
+        match = _BRACKET_RE.match(raw, pos)
+        if match is None:
+            raise PatchError(
+                f"invalid path {path!r}: malformed list index in segment {raw!r} "
+                "(expected '[<int>]')"
+            )
+        inner = match.group(1).strip()
+        try:
+            out.append(int(inner))
+        except ValueError:
+            raise PatchError(
+                f"invalid path {path!r}: list index '[{match.group(1)}]' is not an integer"
+            ) from None
+        pos = match.end()
+
+    return out
+
+
+def _render(segments: list[Segment]) -> str:
+    """Render parsed segments back to a readable path, for error messages."""
+    parts: list[str] = []
+    for seg in segments:
+        if isinstance(seg, int):
+            parts.append(f"[{seg}]")
+        else:
+            parts.append(f".{seg}" if parts else seg)
+    return "".join(parts)
+
+
+# ── Traversal ─────────────────────────────────────────────────────────────────
+
+
+def _key_hint(node: dict[str, Any], key: str) -> str:
+    """Build a 'did you mean' / 'available keys' hint for a missing dict key."""
+    keys = [str(k) for k in node]
+    if not keys:
+        return " — the object at that path is empty"
+    close = difflib.get_close_matches(key, keys, n=1, cutoff=0.6)
+    if close:
+        return f" — did you mean {close[0]!r}?"
+    shown = sorted(keys)[:_MAX_KEYS_IN_ERROR]
+    suffix = ", ..." if len(keys) > _MAX_KEYS_IN_ERROR else ""
+    return f" — available keys: {', '.join(repr(k) for k in shown)}{suffix}"
+
+
+def _descend(
+    node: Any,
+    seg: Segment,
+    walked: list[Segment],
+    next_seg: Segment | None,
+    path: str,
+    create_missing: bool,
+) -> Any:
+    """Step one segment deeper, optionally creating a missing dict on the way."""
+    where = _render(walked) or "<root>"
+
+    if isinstance(seg, int):
+        if not isinstance(node, list):
+            raise PatchError(
+                f"cannot apply patch at {path!r}: expected a list at {where!r}, "
+                f"found {type(node).__name__}"
+            )
+        if not -len(node) <= seg < len(node):
+            raise PatchError(
+                f"cannot apply patch at {path!r}: index [{seg}] is out of range at "
+                f"{where!r} (list has {len(node)} item(s))"
+            )
+        return node[seg]
+
+    if not isinstance(node, dict):
+        raise PatchError(
+            f"cannot apply patch at {path!r}: expected an object at {where!r}, "
+            f"found {type(node).__name__}"
+        )
+
+    if seg in node:
+        return node[seg]
+
+    if not create_missing:
+        raise PatchError(
+            f"cannot apply patch at {path!r}: key {seg!r} not found at {where!r}"
+            + _key_hint(node, seg)
+        )
+    if isinstance(next_seg, int):
+        raise PatchError(
+            f"cannot apply patch at {path!r}: key {seg!r} is missing at {where!r} and "
+            "cannot be created because the next segment is a list index — "
+            "create the list explicitly with a 'set' op first"
+        )
+    created: dict[str, Any] = {}
+    node[seg] = created
+    return created
+
+
+def _resolve_parent(
+    state: dict[str, Any],
+    segments: list[Segment],
+    path: str,
+    create_missing: bool,
+) -> tuple[Any, Segment]:
+    """Walk to the container holding the final segment.
+
+    Returns:
+        (container, final_segment)
+    """
+    node: Any = state
+    for i, seg in enumerate(segments[:-1]):
+        next_seg = segments[i + 1]
+        node = _descend(node, seg, segments[:i], next_seg, path, create_missing)
+    return node, segments[-1]
+
+
+def _read(container: Any, seg: Segment) -> tuple[Any, bool]:
+    """Read the value at *seg* in *container*. Returns (value, existed)."""
+    if isinstance(seg, int):
+        if isinstance(container, list) and -len(container) <= seg < len(container):
+            return container[seg], True
+        return None, False
+    if isinstance(container, dict) and seg in container:
+        return container[seg], True
+    return None, False
+
+
+# ── Ops ───────────────────────────────────────────────────────────────────────
+
+
+def _write(container: Any, seg: Segment, value: Any, path: str) -> None:
+    """Write *value* at *seg* in *container*, validating the container type."""
+    if isinstance(seg, int):
+        if not isinstance(container, list):
+            raise PatchError(
+                f"cannot apply patch at {path!r}: index [{seg}] requires a list, "
+                f"found {type(container).__name__}"
+            )
+        if not -len(container) <= seg < len(container):
+            raise PatchError(
+                f"cannot apply patch at {path!r}: index [{seg}] is out of range "
+                f"(list has {len(container)} item(s)) — patches edit existing "
+                "positions and cannot append"
+            )
+        container[seg] = value
+        return
+
+    if not isinstance(container, dict):
+        raise PatchError(
+            f"cannot apply patch at {path!r}: key {seg!r} requires an object, "
+            f"found {type(container).__name__}"
+        )
+    container[seg] = value
+
+
+def _op_set(
+    state: dict[str, Any], path: str, value: Any, create_missing: bool
+) -> PatchChange:
+    segments = parse_path(path)
+    container, last = _resolve_parent(state, segments, path, create_missing)
+    before, existed = _read(container, last)
+    if not existed and isinstance(last, str) and not create_missing:
+        # Setting a brand-new key is only allowed with create_missing, so that a
+        # typo produces an error instead of silently adding a field.
+        if isinstance(container, dict):
+            raise PatchError(
+                f"cannot apply patch at {path!r}: key {last!r} does not exist"
+                + _key_hint(container, last)
+                + " (pass create_missing=True to add new keys)"
+            )
+    _write(container, last, value, path)
+    return PatchChange(op="set", path=path, before=before, after=value, existed=existed)
+
+
+def _op_delete(state: dict[str, Any], path: str) -> PatchChange:
+    segments = parse_path(path)
+    container, last = _resolve_parent(state, segments, path, create_missing=False)
+    before, existed = _read(container, last)
+    if not existed:
+        where = _render(segments[:-1]) or "<root>"
+        hint = ""
+        if isinstance(container, dict) and isinstance(last, str):
+            hint = _key_hint(container, last)
+        raise PatchError(
+            f"cannot delete {path!r}: nothing found at {where!r}{hint}"
+        )
+    if isinstance(last, int):
+        if not isinstance(container, list):
+            raise PatchError(
+                f"cannot delete {path!r}: index [{last}] requires a list, "
+                f"found {type(container).__name__}"
+            )
+        del container[last]
+    else:
+        del container[last]
+    return PatchChange(op="delete", path=path, before=before, after=None, existed=True)
+
+
+def _op_merge(
+    state: dict[str, Any], path: str, value: Any, create_missing: bool
+) -> PatchChange:
+    if not isinstance(value, dict):
+        raise PatchError(
+            f"cannot merge at {path!r}: merge values must be objects, "
+            f"got {type(value).__name__} — use 'set' to replace a non-object value"
+        )
+    segments = parse_path(path)
+    container, last = _resolve_parent(state, segments, path, create_missing)
+    before, existed = _read(container, last)
+
+    if not existed:
+        if not create_missing:
+            hint = (
+                _key_hint(container, last)
+                if isinstance(container, dict) and isinstance(last, str)
+                else ""
+            )
+            raise PatchError(
+                f"cannot merge at {path!r}: nothing found to merge into{hint} "
+                "(pass create_missing=True to create it)"
+            )
+        merged: dict[str, Any] = dict(value)
+    else:
+        if not isinstance(before, dict):
+            raise PatchError(
+                f"cannot merge at {path!r}: expected an object to merge into, "
+                f"found {type(before).__name__} — use 'set' to replace it"
+            )
+        merged = {**before, **value}
+
+    _write(container, last, merged, path)
+    return PatchChange(
+        op="merge", path=path, before=before, after=merged, existed=existed
+    )
+
+
+# ── Validation ────────────────────────────────────────────────────────────────
+
+
+def validate_patch(patch: Any) -> None:
+    """Validate a patch document's shape without applying it.
+
+    Raises:
+        PatchError: if the document is malformed.
+    """
+    if not isinstance(patch, dict):
+        raise PatchError(
+            f"patch must be a JSON object, got {type(patch).__name__}"
+        )
+
+    unknown = sorted(set(patch) - _VALID_OPS)
+    if unknown:
+        raise PatchError(
+            f"unknown patch op(s): {', '.join(repr(k) for k in unknown)} — "
+            f"valid ops are {', '.join(sorted(_VALID_OPS))}"
+        )
+
+    for op in ("set", "merge"):
+        if op not in patch:
+            continue
+        body = patch[op]
+        if not isinstance(body, dict):
+            raise PatchError(
+                f"patch op {op!r} must be an object mapping paths to values, "
+                f"got {type(body).__name__}"
+            )
+        for raw_path in body:
+            if not isinstance(raw_path, str):
+                raise PatchError(
+                    f"patch op {op!r} has a non-string path: {raw_path!r}"
+                )
+            parse_path(raw_path)
+        if op == "merge":
+            for raw_path, value in body.items():
+                if not isinstance(value, dict):
+                    raise PatchError(
+                        f"cannot merge at {raw_path!r}: merge values must be objects, "
+                        f"got {type(value).__name__} — use 'set' to replace a "
+                        "non-object value"
+                    )
+
+    if "delete" in patch:
+        _normalize_deletes(patch["delete"])
+
+    _check_conflicts(patch)
+
+
+def _normalize_deletes(body: Any) -> list[str]:
+    """Coerce the 'delete' op body to a list of validated path strings."""
+    if isinstance(body, str):
+        paths = [body]
+    elif isinstance(body, list):
+        paths = []
+        for item in body:
+            if not isinstance(item, str):
+                raise PatchError(
+                    f"patch op 'delete' must contain path strings, "
+                    f"got {type(item).__name__}: {item!r}"
+                )
+            paths.append(item)
+    else:
+        raise PatchError(
+            "patch op 'delete' must be a list of paths (or a single path string), "
+            f"got {type(body).__name__}"
+        )
+    for p in paths:
+        parse_path(p)
+    return paths
+
+
+def _check_conflicts(patch: dict[str, Any]) -> None:
+    """Reject a path targeted by more than one op group.
+
+    Paths are compared after parsing, so ``a[0]`` and ``a.[0]`` are recognised
+    as the same target.
+    """
+    seen: dict[tuple[Segment, ...], tuple[str, str]] = {}
+    for op in _APPLY_ORDER:
+        if op not in patch:
+            continue
+        if op == "delete":
+            paths = _normalize_deletes(patch[op])
+        else:
+            paths = list(patch[op])
+        for raw_path in paths:
+            key = tuple(parse_path(raw_path))
+            if key in seen:
+                prev_op, prev_path = seen[key]
+                raise PatchError(
+                    f"conflicting patch ops: {prev_path!r} in {prev_op!r} and "
+                    f"{raw_path!r} in {op!r} target the same path — "
+                    "use a single op per path"
+                )
+            seen[key] = (op, raw_path)
+
+
+# ── Public entry points ───────────────────────────────────────────────────────
+
+
+def _apply(
+    state: dict[str, Any], patch: dict[str, Any], create_missing: bool
+) -> tuple[dict[str, Any], list[PatchChange]]:
+    """Validate, deep-copy, and apply — the shared core of apply/preview."""
+    if not isinstance(state, dict):
+        raise PatchError(
+            f"state must be a dict to be patched, got {type(state).__name__}"
+        )
+    validate_patch(patch)
+
+    try:
+        working = copy.deepcopy(state)
+    except Exception as exc:  # pragma: no cover - exotic un-copyable states
+        raise PatchError(f"state could not be copied for patching: {exc}") from exc
+
+    changes: list[PatchChange] = []
+    for op in _APPLY_ORDER:
+        if op not in patch:
+            continue
+        if op == "delete":
+            for raw_path in _normalize_deletes(patch[op]):
+                changes.append(_op_delete(working, raw_path))
+        elif op == "set":
+            for raw_path, value in patch[op].items():
+                changes.append(_op_set(working, raw_path, value, create_missing))
+        else:
+            for raw_path, value in patch[op].items():
+                changes.append(_op_merge(working, raw_path, value, create_missing))
+
+    return working, changes
+
+
+def apply_patch(
+    state: dict[str, Any],
+    patch: dict[str, Any],
+    create_missing: bool = False,
+) -> dict[str, Any]:
+    """Apply *patch* to *state* and return a new dict.
+
+    The input state is never mutated.  Ops run in a fixed order — delete,
+    then set, then merge — so the result does not depend on key ordering.
+
+    Args:
+        state: the state dict to patch (typically a recorded ``input_state``).
+        patch: the patch document.
+        create_missing: allow ``set``/``merge`` to create keys that do not
+            exist yet.  Off by default so a mistyped path is an error rather
+            than a silently added field.
+
+    Raises:
+        PatchError: if the patch is malformed or does not apply cleanly.
+    """
+    patched, _ = _apply(state, patch, create_missing)
+    return patched
+
+
+def preview_patch(
+    state: dict[str, Any],
+    patch: dict[str, Any],
+    create_missing: bool = False,
+) -> list[PatchChange]:
+    """Return the changes *patch* would make to *state*, without keeping them.
+
+    Raises the same errors as :func:`apply_patch`, so a preview doubles as a
+    dry run.
+    """
+    _, changes = _apply(state, patch, create_missing)
+    return changes
+
+
+def format_changes(changes: list[PatchChange], max_value_chars: int = 120) -> list[str]:
+    """Render changes as human-readable one-liners for CLI/UI display."""
+    lines: list[str] = []
+    for change in changes:
+        if change.op == "delete":
+            lines.append(f"- {change.path}  (was {_brief(change.before, max_value_chars)})")
+        elif not change.existed:
+            lines.append(f"+ {change.path}  = {_brief(change.after, max_value_chars)}")
+        else:
+            lines.append(
+                f"~ {change.path}  "
+                f"{_brief(change.before, max_value_chars)} -> "
+                f"{_brief(change.after, max_value_chars)}"
+            )
+    return lines
+
+
+def _brief(value: Any, max_chars: int) -> str:
+    """Compact, never-raising repr of a value for display."""
+    try:
+        import json
+
+        text = json.dumps(value, default=str, ensure_ascii=False)
+    except Exception:
+        text = repr(value)
+    if len(text) > max_chars:
+        return text[: max_chars - 1] + "\u2026"
+    return text

--- a/src/argus/storage.py
+++ b/src/argus/storage.py
@@ -279,6 +279,7 @@ def _deserialize_run(data: dict[str, Any]) -> RunRecord:
         subgraph_run_ids=data.get("subgraph_run_ids", []),
         interrupted=data.get("interrupted", False),
         interrupt_node=data.get("interrupt_node"),
+        state_patch=data.get("state_patch"),
         behavior_config=behavior_config,
         correlation=correlation,
         llm_investigation=llm_investigation,

--- a/tests/test_replay_patch.py
+++ b/tests/test_replay_patch.py
@@ -1,0 +1,238 @@
+"""End-to-end tests for patched replay (time-travel part 2).
+
+Verifies that a patch applied to a recorded node's input state actually
+reaches the resumed trajectory, that upstream nodes stay frozen, and that
+the patch is persisted on the replay run for provenance.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+from argus.models import LLMInvestigationConfig
+from argus.replay import ReplayEngine
+from argus.session import ArgusSession
+from argus.state_patch import PatchError
+from argus.storage import load_run
+
+_MODULE_NAME = "argus_patch_pipeline"
+
+_PIPELINE_SRC = '''
+"""Throwaway pipeline used by the patched-replay tests."""
+
+CALLS = []
+
+
+def fetch(state):
+    CALLS.append("fetch")
+    return {"docs": ["d1", "d2"], "status": "PLACEHOLDER"}
+
+
+def transform(state):
+    CALLS.append("transform")
+    return {"summary": "docs=%d status=%s" % (len(state["docs"]), state["status"])}
+
+
+def finish(state):
+    CALLS.append("finish")
+    return {"done": True, "final": state["summary"]}
+'''
+
+_ORDER = ["fetch", "transform", "finish"]
+
+
+@pytest.fixture(autouse=True)
+def _isolate(tmp_path, monkeypatch):
+    """Clean tmp cwd, importable pipeline module, no LLM calls."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / f"{_MODULE_NAME}.py").write_text(_PIPELINE_SRC, encoding="utf-8")
+    monkeypatch.syspath_prepend(str(tmp_path))
+    monkeypatch.setattr("argus.llm_proxy.is_available", lambda: False)
+    yield
+    sys.modules.pop(_MODULE_NAME, None)
+
+
+def _pipeline():
+    import importlib
+
+    sys.modules.pop(_MODULE_NAME, None)
+    return importlib.import_module(_MODULE_NAME)
+
+
+def _record_run(initial_state=None):
+    """Run the pipeline under ARGUS and return (run_id, module)."""
+    mod = _pipeline()
+    session = ArgusSession(llm_investigation=LLMInvestigationConfig(enabled=False))
+    session.set_node_names(list(_ORDER))
+    session.set_edges({"fetch": ["transform"], "transform": ["finish"]})
+
+    # Set before execution: the session auto-finalizes once every terminal
+    # node has completed, so refs assigned afterwards never reach the record.
+    session.node_fn_refs = {n: f"{_MODULE_NAME}:{n}" for n in _ORDER}
+    session.node_fn_paths = {n: f"{_MODULE_NAME}.py" for n in _ORDER}
+
+    wrapped = {name: session.wrap(name, getattr(mod, name)) for name in _ORDER}
+
+    state = dict(initial_state or {"query": "hello"})
+    for name in _ORDER:
+        partial = wrapped[name](state)
+        state = {**state, **partial}
+
+    session.finalize()
+    return session.run_id, mod
+
+
+def _step(record, node_name):
+    return next(s for s in record.steps if s.node_name == node_name)
+
+
+# ── the core promise ──────────────────────────────────────────────────────────
+
+
+@pytest.mark.integration
+def test_patched_value_reaches_the_resumed_trajectory():
+    run_id, _ = _record_run()
+    original = load_run(run_id)
+    assert "PLACEHOLDER" in _step(original, "finish").input_state["summary"]
+
+    new_id = ReplayEngine().replay(
+        run_id, "transform", patch={"set": {"status": "OK"}}
+    )
+
+    replayed = load_run(new_id)
+    assert _step(replayed, "transform").output_dict["summary"] == "docs=2 status=OK"
+    assert _step(replayed, "finish").output_dict["final"] == "docs=2 status=OK"
+
+
+@pytest.mark.integration
+def test_upstream_nodes_are_not_re_executed():
+    run_id, _ = _record_run()
+
+    ReplayEngine().replay(run_id, "transform", patch={"set": {"status": "OK"}})
+
+    # _import_fn reloads the module, so CALLS holds only the replay's calls.
+    calls = sys.modules[_MODULE_NAME].CALLS
+    assert "fetch" not in calls
+    assert calls == ["transform", "finish"]
+
+
+@pytest.mark.integration
+def test_delete_op_reproduces_a_dropped_field_crash():
+    """Deleting a field on demand reproduces the exact downstream failure.
+
+    A node crash during replay propagates to the caller (pre-existing
+    ReplayEngine behaviour — session.finalize() is not reached), so the
+    reproduction surfaces as the original exception rather than a record.
+    """
+    run_id, _ = _record_run()
+
+    with pytest.raises(KeyError, match="docs"):
+        ReplayEngine().replay(run_id, "transform", patch={"delete": ["docs"]})
+
+    assert sys.modules[_MODULE_NAME].CALLS == ["transform"]
+
+
+# ── provenance ────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.integration
+def test_patch_is_persisted_and_round_trips_through_storage():
+    run_id, _ = _record_run()
+    patch = {"set": {"status": "OK"}}
+
+    new_id = ReplayEngine().replay(run_id, "transform", patch=patch)
+
+    # from the in-process load
+    assert load_run(new_id).state_patch == patch
+    # and straight off disk, so the JSON schema carries it
+    raw = json.loads(Path(f".argus/runs/{new_id}.json").read_text(encoding="utf-8"))
+    assert raw["state_patch"] == patch
+
+
+@pytest.mark.integration
+def test_unpatched_replay_records_no_patch():
+    run_id, _ = _record_run()
+    new_id = ReplayEngine().replay(run_id, "transform")
+    assert load_run(new_id).state_patch is None
+
+
+@pytest.mark.integration
+def test_replay_links_back_to_parent_with_patch():
+    run_id, _ = _record_run()
+    new_id = ReplayEngine().replay(run_id, "transform", patch={"set": {"status": "OK"}})
+    replayed = load_run(new_id)
+    assert replayed.parent_run_id == run_id
+    assert replayed.replay_from_step == "transform"
+
+
+# ── safety ────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.integration
+def test_bad_patch_fails_before_any_node_runs():
+    run_id, _ = _record_run()
+
+    sys.modules[_MODULE_NAME].CALLS.clear()
+
+    with pytest.raises(PatchError, match="cannot patch input state for node 'transform'"):
+        ReplayEngine().replay(run_id, "transform", patch={"set": {"stauts": "OK"}})
+
+    assert sys.modules[_MODULE_NAME].CALLS == []
+
+
+@pytest.mark.integration
+def test_patch_error_names_the_node_and_suggests_the_key():
+    run_id, _ = _record_run()
+    with pytest.raises(PatchError, match="did you mean 'status'"):
+        ReplayEngine().replay(run_id, "transform", patch={"set": {"stauts": "OK"}})
+
+
+@pytest.mark.integration
+def test_original_run_is_left_untouched_on_disk():
+    run_id, _ = _record_run()
+    before = Path(f".argus/runs/{run_id}.json").read_text(encoding="utf-8")
+
+    ReplayEngine().replay(run_id, "transform", patch={"set": {"status": "OK"}})
+
+    assert Path(f".argus/runs/{run_id}.json").read_text(encoding="utf-8") == before
+
+
+@pytest.mark.integration
+def test_create_missing_gates_new_keys():
+    run_id, _ = _record_run()
+    patch = {"set": {"brand_new": 1}}
+
+    with pytest.raises(PatchError):
+        ReplayEngine().replay(run_id, "transform", patch=patch)
+
+    new_id = ReplayEngine().replay(run_id, "transform", patch=patch, create_missing=True)
+    assert load_run(new_id).state_patch == patch
+
+
+# ── single-node mode ──────────────────────────────────────────────────────────
+
+
+@pytest.mark.integration
+def test_replay_node_applies_patch_in_isolation():
+    run_id, _ = _record_run()
+
+    new_id = ReplayEngine().replay_node(
+        run_id, "transform", patch={"set": {"status": "OK"}}
+    )
+
+    replayed = load_run(new_id)
+    assert len(replayed.steps) == 1
+    assert replayed.steps[0].output_dict["summary"] == "docs=2 status=OK"
+    assert replayed.state_patch == {"set": {"status": "OK"}}
+    assert sys.modules[_MODULE_NAME].CALLS == ["transform"]
+
+
+@pytest.mark.integration
+def test_replay_node_rejects_a_bad_patch():
+    run_id, _ = _record_run()
+    with pytest.raises(PatchError, match="cannot patch input state"):
+        ReplayEngine().replay_node(run_id, "transform", patch={"delete": ["nope"]})

--- a/tests/test_replay_patch.py
+++ b/tests/test_replay_patch.py
@@ -429,3 +429,151 @@ def test_api_single_node_mode_accepts_a_patch(ui_server):
     replayed = load_run(result["run_id"])
     assert len(replayed.steps) == 1
     assert replayed.steps[0].output_dict["summary"] == "docs=2 status=OK"
+
+
+# ── preview endpoint (step 1.5) ───────────────────────────────────────────────
+
+
+@pytest.mark.integration
+def test_preview_returns_changes_and_summary(ui_server):
+    post, _ = ui_server
+    run_id, _ = _record_run()
+
+    status, body = post(
+        "/api/replay/preview",
+        {"run_id": run_id, "from_step": "transform", "patch": {"set": {"status": "OK"}}},
+    )
+
+    assert status == 200
+    assert body["changes"] == [
+        {
+            "op": "set",
+            "path": "status",
+            "before": "PLACEHOLDER",
+            "after": "OK",
+            "existed": True,
+        }
+    ]
+    assert body["summary"] == ['~ status  "PLACEHOLDER" -> "OK"']
+
+
+@pytest.mark.integration
+def test_preview_runs_nothing_and_changes_nothing(ui_server):
+    """A preview that executes a node, or starts a job, is a bug."""
+    from argus.cli import cmd_open_ui
+
+    post, _ = ui_server
+    run_id, _ = _record_run()
+    before = Path(f".argus/runs/{run_id}.json").read_text(encoding="utf-8")
+    jobs_before = len(cmd_open_ui._replay_jobs)
+    sys.modules[_MODULE_NAME].CALLS.clear()
+
+    status, _ = post(
+        "/api/replay/preview",
+        {"run_id": run_id, "from_step": "transform", "patch": {"set": {"status": "OK"}}},
+    )
+
+    assert status == 200
+    assert Path(f".argus/runs/{run_id}.json").read_text(encoding="utf-8") == before
+    assert len(cmd_open_ui._replay_jobs) == jobs_before
+    assert sys.modules[_MODULE_NAME].CALLS == []
+
+
+@pytest.mark.integration
+def test_preview_reports_a_delete_and_an_added_key(ui_server):
+    post, _ = ui_server
+    run_id, _ = _record_run()
+
+    status, body = post(
+        "/api/replay/preview",
+        {
+            "run_id": run_id,
+            "from_step": "transform",
+            "patch": {"delete": ["docs"], "set": {"brand_new": 5}},
+            "create_missing": True,
+        },
+    )
+
+    assert status == 200
+    by_path = {c["path"]: c for c in body["changes"]}
+    assert by_path["docs"]["op"] == "delete"
+    assert by_path["docs"]["before"] == ["d1", "d2"]
+    assert by_path["brand_new"]["existed"] is False
+    assert by_path["brand_new"]["after"] == 5
+
+
+@pytest.mark.integration
+def test_preview_caps_large_values(ui_server):
+    """The editor calls this on every typing pause — it must not ship megabytes."""
+    from argus.cli.cmd_open_ui import _MAX_PREVIEW_VALUE_CHARS
+
+    post, _ = ui_server
+    run_id, _ = _record_run()
+    blob = "x" * (_MAX_PREVIEW_VALUE_CHARS * 4)
+
+    status, body = post(
+        "/api/replay/preview",
+        {"run_id": run_id, "from_step": "transform", "patch": {"set": {"status": blob}}},
+    )
+
+    assert status == 200
+    after = body["changes"][0]["after"]
+    assert after["__argus_truncated__"] is True
+    assert after["full_length"] > _MAX_PREVIEW_VALUE_CHARS
+    assert len(after["preview"]) <= _MAX_PREVIEW_VALUE_CHARS
+
+
+@pytest.mark.integration
+def test_preview_rejects_a_bad_path_with_the_hint(ui_server):
+    post, _ = ui_server
+    run_id, _ = _record_run()
+
+    status, body = post(
+        "/api/replay/preview",
+        {"run_id": run_id, "from_step": "transform", "patch": {"set": {"stauts": "OK"}}},
+    )
+
+    assert status == 400
+    assert body["error"] == "invalid_patch"
+    assert "did you mean 'status'" in body["message"]
+
+
+@pytest.mark.integration
+def test_preview_matches_what_replay_accepts(ui_server):
+    """Preview and replay must agree — a preview that lies is worse than none."""
+    post, get = ui_server
+    run_id, _ = _record_run()
+    payload = {"run_id": run_id, "from_step": "transform", "patch": {"set": {"fresh": 1}}}
+
+    preview_status, _ = post("/api/replay/preview", payload)
+    replay_status, _ = post("/api/replay", payload)
+    assert preview_status == replay_status == 400
+
+    ok_payload = {**payload, "create_missing": True}
+    preview_status, _ = post("/api/replay/preview", ok_payload)
+    replay_status, replay_body = post("/api/replay", ok_payload)
+    assert preview_status == 200
+    assert replay_status == 202
+    assert _await_job(get, replay_body["job_id"])["status"] == "done"
+
+
+@pytest.mark.integration
+def test_preview_error_cases(ui_server):
+    post, _ = ui_server
+    run_id, _ = _record_run()
+
+    status, body = post(
+        "/api/replay/preview",
+        {"run_id": run_id, "from_step": "nope", "patch": {"set": {"status": "OK"}}},
+    )
+    assert status == 404
+    assert body["error"] == "unknown_node"
+
+    status, _ = post(
+        "/api/replay/preview",
+        {"run_id": "does-not-exist", "from_step": "transform", "patch": {}},
+    )
+    assert status == 404
+
+    status, _ = post("/api/replay/preview", {"run_id": run_id, "from_step": "transform"})
+    assert status == 400  # patch is required

--- a/tests/test_replay_patch.py
+++ b/tests/test_replay_patch.py
@@ -236,3 +236,196 @@ def test_replay_node_rejects_a_bad_patch():
     run_id, _ = _record_run()
     with pytest.raises(PatchError, match="cannot patch input state"):
         ReplayEngine().replay_node(run_id, "transform", patch={"delete": ["nope"]})
+
+
+# ── HTTP endpoint (step 1.4) ──────────────────────────────────────────────────
+
+
+@pytest.fixture
+def ui_server(tmp_path):
+    """Start the real dashboard handler on an ephemeral port."""
+    import json as _json
+    import threading as _threading
+    import urllib.error
+    import urllib.request
+    from http.server import ThreadingHTTPServer
+
+    from argus.cli.cmd_open_ui import _make_handler
+
+    runs_dir = tmp_path / ".argus" / "runs"
+    logs_dir = tmp_path / ".argus" / "logs"
+    runs_dir.mkdir(parents=True, exist_ok=True)
+    logs_dir.mkdir(parents=True, exist_ok=True)
+
+    handler = _make_handler(runs_dir, logs_dir, None, tmp_path)
+    server = ThreadingHTTPServer(("localhost", 0), handler)
+    thread = _threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    port = server.server_address[1]
+
+    def post(path, payload):
+        req = urllib.request.Request(
+            f"http://localhost:{port}{path}",
+            data=_json.dumps(payload).encode(),
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=10) as resp:
+                return resp.status, _json.loads(resp.read() or b"{}")
+        except urllib.error.HTTPError as exc:
+            return exc.code, _json.loads(exc.read() or b"{}")
+
+    def get(path):
+        with urllib.request.urlopen(f"http://localhost:{port}{path}", timeout=10) as resp:
+            return resp.status, _json.loads(resp.read() or b"{}")
+
+    try:
+        yield post, get
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def _await_job(get, job_id, timeout=15.0):
+    """Poll the replay job until it leaves 'running'."""
+    import time
+
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        _, body = get(f"/api/replay/status/{job_id}")
+        if body.get("status") != "running":
+            return body
+        time.sleep(0.05)
+    raise AssertionError(f"job {job_id} did not finish within {timeout}s")
+
+
+@pytest.mark.integration
+def test_api_replay_accepts_a_patch(ui_server):
+    post, get = ui_server
+    run_id, _ = _record_run()
+
+    status, body = post(
+        "/api/replay",
+        {"run_id": run_id, "from_step": "transform", "patch": {"set": {"status": "OK"}}},
+    )
+    assert status == 202
+    assert "job_id" in body
+
+    result = _await_job(get, body["job_id"])
+    assert result["status"] == "done", result
+
+    replayed = load_run(result["run_id"])
+    assert replayed.state_patch == {"set": {"status": "OK"}}
+    assert replayed.parent_run_id == run_id
+    assert _step(replayed, "finish").output_dict["final"] == "docs=2 status=OK"
+
+
+@pytest.mark.integration
+def test_api_replay_still_works_without_a_patch(ui_server):
+    post, get = ui_server
+    run_id, _ = _record_run()
+
+    status, body = post("/api/replay", {"run_id": run_id, "from_step": "transform"})
+    assert status == 202
+
+    result = _await_job(get, body["job_id"])
+    assert result["status"] == "done", result
+    assert load_run(result["run_id"]).state_patch is None
+
+
+@pytest.mark.integration
+def test_api_rejects_a_bad_path_with_the_hint_and_starts_no_job(ui_server):
+    from argus.cli import cmd_open_ui
+
+    post, _ = ui_server
+    run_id, _ = _record_run()
+    jobs_before = len(cmd_open_ui._replay_jobs)
+
+    status, body = post(
+        "/api/replay",
+        {"run_id": run_id, "from_step": "transform", "patch": {"set": {"stauts": "OK"}}},
+    )
+
+    assert status == 400
+    assert body["error"] == "invalid_patch"
+    assert "did you mean 'status'" in body["message"]
+    assert len(cmd_open_ui._replay_jobs) == jobs_before
+
+
+@pytest.mark.integration
+def test_api_rejects_a_malformed_patch_document(ui_server):
+    post, _ = ui_server
+    run_id, _ = _record_run()
+
+    status, body = post(
+        "/api/replay",
+        {"run_id": run_id, "from_step": "transform", "patch": {"bogus_op": {"a": 1}}},
+    )
+    assert status == 400
+    assert "unknown patch op" in body["message"]
+
+
+@pytest.mark.integration
+def test_api_rejects_a_non_object_patch(ui_server):
+    post, _ = ui_server
+    run_id, _ = _record_run()
+
+    status, body = post(
+        "/api/replay",
+        {"run_id": run_id, "from_step": "transform", "patch": ["not", "an", "object"]},
+    )
+    assert status == 400
+    assert body["error"] == "invalid_patch"
+
+
+@pytest.mark.integration
+def test_api_reports_unknown_node_when_patching(ui_server):
+    post, _ = ui_server
+    run_id, _ = _record_run()
+
+    status, body = post(
+        "/api/replay",
+        {"run_id": run_id, "from_step": "nope", "patch": {"set": {"status": "OK"}}},
+    )
+    assert status == 404
+    assert body["error"] == "unknown_node"
+    assert "transform" in body["message"]
+
+
+@pytest.mark.integration
+def test_api_create_missing_flag_is_honoured(ui_server):
+    post, get = ui_server
+    run_id, _ = _record_run()
+    payload = {"run_id": run_id, "from_step": "transform", "patch": {"set": {"fresh": 1}}}
+
+    status, _ = post("/api/replay", payload)
+    assert status == 400
+
+    status, body = post("/api/replay", {**payload, "create_missing": True})
+    assert status == 202
+    result = _await_job(get, body["job_id"])
+    assert result["status"] == "done", result
+
+
+@pytest.mark.integration
+def test_api_single_node_mode_accepts_a_patch(ui_server):
+    post, get = ui_server
+    run_id, _ = _record_run()
+
+    status, body = post(
+        "/api/replay",
+        {
+            "run_id": run_id,
+            "from_step": "transform",
+            "mode": "node",
+            "patch": {"set": {"status": "OK"}},
+        },
+    )
+    assert status == 202
+
+    result = _await_job(get, body["job_id"])
+    assert result["status"] == "done", result
+    replayed = load_run(result["run_id"])
+    assert len(replayed.steps) == 1
+    assert replayed.steps[0].output_dict["summary"] == "docs=2 status=OK"

--- a/tests/test_state_patch.py
+++ b/tests/test_state_patch.py
@@ -339,3 +339,118 @@ def test_patch_handles_argus_signal_field_path_form():
     signal_path = "result.items.[0].summary"
     out = apply_patch(state, {"set": {signal_path: "real summary"}})
     assert out["result"]["items"][0]["summary"] == "real summary"
+
+
+# ── CLI patch construction (part 3) ───────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_build_patch_returns_none_when_empty():
+    from argus.cli.cmd_replay import build_patch
+
+    assert build_patch(None, None, None) is None
+    assert build_patch(None, [], []) is None
+
+
+@pytest.mark.unit
+def test_build_patch_from_set_pairs():
+    from argus.cli.cmd_replay import build_patch
+
+    patch = build_patch(None, ["meta.retries=0", "query=hello"], None)
+    assert patch == {"set": {"meta.retries": 0, "query": "hello"}}
+
+
+@pytest.mark.unit
+def test_set_values_are_parsed_as_json_with_string_fallback():
+    from argus.cli.cmd_replay import build_patch
+
+    patch = build_patch(
+        None,
+        ["n=42", "f=1.5", "b=true", "nil=null", "obj={\"a\": 1}", "arr=[1,2]", "s=plain"],
+        None,
+    )
+    values = patch["set"]
+    assert values["n"] == 42
+    assert values["f"] == 1.5
+    assert values["b"] is True
+    assert values["nil"] is None
+    assert values["obj"] == {"a": 1}
+    assert values["arr"] == [1, 2]
+    assert values["s"] == "plain"
+
+
+@pytest.mark.unit
+def test_set_value_may_contain_equals_signs():
+    from argus.cli.cmd_replay import build_patch
+
+    patch = build_patch(None, ["query=a=b=c"], None)
+    assert patch["set"]["query"] == "a=b=c"
+
+
+@pytest.mark.unit
+def test_build_patch_from_delete_flags():
+    from argus.cli.cmd_replay import build_patch
+
+    assert build_patch(None, None, ["a", "b.c"]) == {"delete": ["a", "b.c"]}
+
+
+@pytest.mark.unit
+def test_build_patch_rejects_malformed_set():
+    from argus.cli.cmd_replay import build_patch
+
+    with pytest.raises(PatchError, match="expected 'path=value'"):
+        build_patch(None, ["nonsense"], None)
+    with pytest.raises(PatchError, match="the path is empty"):
+        build_patch(None, ["=value"], None)
+
+
+@pytest.mark.unit
+def test_build_patch_reads_a_json_file(tmp_path, monkeypatch):
+    import json
+
+    from argus.cli.cmd_replay import build_patch
+
+    monkeypatch.chdir(tmp_path)
+    doc = {"set": {"a": 1}, "delete": ["b"]}
+    (tmp_path / "p.json").write_text(json.dumps(doc), encoding="utf-8")
+    assert build_patch("p.json", None, None) == doc
+
+
+@pytest.mark.unit
+def test_flags_layer_on_top_of_a_patch_file(tmp_path, monkeypatch):
+    import json
+
+    from argus.cli.cmd_replay import build_patch
+
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "p.json").write_text(
+        json.dumps({"set": {"a": 1}, "delete": ["x"]}), encoding="utf-8"
+    )
+    patch = build_patch("p.json", ["a=2", "b=3"], ["y"])
+    assert patch["set"] == {"a": 2, "b": 3}  # flag overrides the file
+    assert patch["delete"] == ["x", "y"]
+
+
+@pytest.mark.unit
+def test_build_patch_reports_missing_or_invalid_file(tmp_path, monkeypatch):
+    from argus.cli.cmd_replay import build_patch
+
+    monkeypatch.chdir(tmp_path)
+    with pytest.raises(PatchError, match="patch file not found"):
+        build_patch("nope.json", None, None)
+
+    (tmp_path / "bad.json").write_text("{not json", encoding="utf-8")
+    with pytest.raises(PatchError, match="not valid JSON"):
+        build_patch("bad.json", None, None)
+
+    (tmp_path / "arr.json").write_text("[1,2]", encoding="utf-8")
+    with pytest.raises(PatchError, match="must contain a JSON object"):
+        build_patch("arr.json", None, None)
+
+
+@pytest.mark.unit
+def test_build_patch_output_is_valid_for_the_engine():
+    """Whatever the CLI builds must survive the patch module's validation."""
+    from argus.cli.cmd_replay import build_patch
+
+    validate_patch(build_patch(None, ["a.b=1"], ["c"]))

--- a/tests/test_state_patch.py
+++ b/tests/test_state_patch.py
@@ -1,0 +1,341 @@
+"""Unit tests for the state patch layer (time-travel replay, part 1)."""
+
+import copy
+
+import pytest
+
+from argus.state_patch import (
+    PatchError,
+    apply_patch,
+    format_changes,
+    parse_path,
+    preview_patch,
+    validate_patch,
+)
+
+
+@pytest.fixture
+def state():
+    return {
+        "query": "original query",
+        "items": [{"name": "a", "score": 1}, {"name": "b", "score": 2}],
+        "meta": {"retries": 3, "model": "gpt-4o", "nested": {"deep": True}},
+        "broken_field": "PLACEHOLDER",
+        "count": 7,
+    }
+
+
+# ── Path parsing ──────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "path,expected",
+    [
+        ("query", ["query"]),
+        ("meta.retries", ["meta", "retries"]),
+        ("items[0]", ["items", 0]),
+        ("items.[0]", ["items", 0]),  # argus dotted_path form
+        ("items[0].name", ["items", 0, "name"]),
+        ("items.[0].name", ["items", 0, "name"]),
+        ("matrix[1][2]", ["matrix", 1, 2]),
+        ("[0]", [0]),
+        ("items[-1]", ["items", -1]),
+    ],
+)
+def test_parse_path_forms(path, expected):
+    assert parse_path(path) == expected
+
+
+@pytest.mark.unit
+def test_bracket_and_dotted_index_forms_are_equivalent():
+    assert parse_path("a.b[0].c") == parse_path("a.b.[0].c")
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "bad", ["", "   ", "a..b", ".a", "a.", "a[x]", "a[", "a]", "a[0", "a.[]"]
+)
+def test_parse_path_rejects_malformed(bad):
+    with pytest.raises(PatchError):
+        parse_path(bad)
+
+
+@pytest.mark.unit
+def test_parse_path_rejects_non_string():
+    with pytest.raises(PatchError, match="must be a string"):
+        parse_path(42)
+
+
+# ── set ───────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_set_top_level(state):
+    out = apply_patch(state, {"set": {"query": "fixed"}})
+    assert out["query"] == "fixed"
+
+
+@pytest.mark.unit
+def test_set_nested(state):
+    out = apply_patch(state, {"set": {"meta.retries": 0}})
+    assert out["meta"]["retries"] == 0
+    assert out["meta"]["model"] == "gpt-4o"  # siblings untouched
+
+
+@pytest.mark.unit
+def test_set_list_element(state):
+    out = apply_patch(state, {"set": {"items[1].score": 99}})
+    assert out["items"][1]["score"] == 99
+    assert out["items"][0]["score"] == 1
+
+
+@pytest.mark.unit
+def test_set_negative_index(state):
+    out = apply_patch(state, {"set": {"items[-1].name": "last"}})
+    assert out["items"][-1]["name"] == "last"
+
+
+@pytest.mark.unit
+def test_set_new_key_requires_create_missing(state):
+    with pytest.raises(PatchError, match="does not exist"):
+        apply_patch(state, {"set": {"brand_new": 1}})
+    out = apply_patch(state, {"set": {"brand_new": 1}}, create_missing=True)
+    assert out["brand_new"] == 1
+
+
+@pytest.mark.unit
+def test_set_creates_intermediate_dicts_only_with_flag(state):
+    patch = {"set": {"meta.fresh.leaf": "v"}}
+    with pytest.raises(PatchError, match="not found"):
+        apply_patch(state, patch)
+    out = apply_patch(state, patch, create_missing=True)
+    assert out["meta"]["fresh"]["leaf"] == "v"
+
+
+@pytest.mark.unit
+def test_typo_gets_did_you_mean_hint(state):
+    with pytest.raises(PatchError, match="did you mean 'retries'"):
+        apply_patch(state, {"set": {"meta.retres": 0}})
+
+
+@pytest.mark.unit
+def test_unknown_key_lists_available_keys(state):
+    with pytest.raises(PatchError, match="available keys"):
+        apply_patch(state, {"set": {"meta.zzzzzzzz": 0}})
+
+
+# ── delete ────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_delete_field(state):
+    out = apply_patch(state, {"delete": ["broken_field"]})
+    assert "broken_field" not in out
+    assert "query" in out
+
+
+@pytest.mark.unit
+def test_delete_accepts_bare_string(state):
+    out = apply_patch(state, {"delete": "broken_field"})
+    assert "broken_field" not in out
+
+
+@pytest.mark.unit
+def test_delete_nested_and_list_element(state):
+    out = apply_patch(state, {"delete": ["meta.model", "items[0]"]})
+    assert "model" not in out["meta"]
+    assert len(out["items"]) == 1
+    assert out["items"][0]["name"] == "b"
+
+
+@pytest.mark.unit
+def test_delete_missing_path_errors(state):
+    with pytest.raises(PatchError, match="cannot delete"):
+        apply_patch(state, {"delete": ["nope"]})
+
+
+# ── merge ─────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_merge_preserves_untouched_keys(state):
+    out = apply_patch(state, {"merge": {"meta": {"retries": 0}}})
+    assert out["meta"]["retries"] == 0
+    assert out["meta"]["model"] == "gpt-4o"
+
+
+@pytest.mark.unit
+def test_merge_is_shallow(state):
+    out = apply_patch(state, {"merge": {"meta": {"nested": {"other": 1}}}})
+    assert out["meta"]["nested"] == {"other": 1}  # replaced, not deep-merged
+
+
+@pytest.mark.unit
+def test_merge_non_object_value_rejected(state):
+    with pytest.raises(PatchError, match="must be objects"):
+        apply_patch(state, {"merge": {"meta": "not-a-dict"}})
+
+
+@pytest.mark.unit
+def test_merge_into_non_object_rejected(state):
+    with pytest.raises(PatchError, match="expected an object to merge into"):
+        apply_patch(state, {"merge": {"query": {"a": 1}}})
+
+
+# ── ordering, conflicts, immutability ─────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_ops_apply_in_delete_set_merge_order(state):
+    # 'set' recreates a key that 'delete' removed — delete must run first.
+    out = apply_patch(
+        state,
+        {"set": {"broken_field": "rebuilt"}, "delete": ["count"]},
+    )
+    assert out["broken_field"] == "rebuilt"
+    assert "count" not in out
+
+
+@pytest.mark.unit
+def test_result_independent_of_key_order(state):
+    a = apply_patch(state, {"delete": ["count"], "set": {"query": "x"}})
+    b = apply_patch(state, {"set": {"query": "x"}, "delete": ["count"]})
+    assert a == b
+
+
+@pytest.mark.unit
+def test_conflicting_paths_rejected(state):
+    with pytest.raises(PatchError, match="conflicting patch ops"):
+        apply_patch(state, {"set": {"query": "a"}, "delete": ["query"]})
+
+
+@pytest.mark.unit
+def test_conflict_detection_normalizes_index_syntax(state):
+    with pytest.raises(PatchError, match="conflicting patch ops"):
+        apply_patch(
+            state, {"set": {"items[0].name": "x"}, "merge": {"items.[0].name": {}}}
+        )
+
+
+@pytest.mark.unit
+def test_input_state_never_mutated(state):
+    before = copy.deepcopy(state)
+    apply_patch(state, {"set": {"meta.retries": 0}, "delete": ["broken_field"]})
+    assert state == before
+
+
+@pytest.mark.unit
+def test_deep_structures_are_copied_not_shared(state):
+    out = apply_patch(state, {"set": {"query": "x"}})
+    out["meta"]["model"] = "changed"
+    assert state["meta"]["model"] == "gpt-4o"
+
+
+@pytest.mark.unit
+def test_empty_patch_is_a_noop(state):
+    out = apply_patch(state, {})
+    assert out == state
+    assert preview_patch(state, {}) == []
+
+
+# ── validation ────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_unknown_op_rejected(state):
+    with pytest.raises(PatchError, match="unknown patch op"):
+        apply_patch(state, {"replace": {"query": "x"}})
+
+
+@pytest.mark.unit
+def test_non_dict_patch_rejected(state):
+    with pytest.raises(PatchError, match="must be a JSON object"):
+        apply_patch(state, ["query", "x"])
+
+
+@pytest.mark.unit
+def test_non_dict_state_rejected():
+    with pytest.raises(PatchError, match="state must be a dict"):
+        apply_patch(["not", "a", "dict"], {"set": {"a": 1}})
+
+
+@pytest.mark.unit
+def test_delete_body_must_be_list_or_string(state):
+    with pytest.raises(PatchError, match="must be a list of paths"):
+        apply_patch(state, {"delete": {"query": True}})
+
+
+@pytest.mark.unit
+def test_validate_patch_does_not_need_state():
+    validate_patch({"set": {"a.b": 1}, "delete": ["c"]})
+    with pytest.raises(PatchError):
+        validate_patch({"set": {"a..b": 1}})
+
+
+@pytest.mark.unit
+def test_index_out_of_range_reports_length(state):
+    with pytest.raises(PatchError, match=r"list has 2 item\(s\)"):
+        apply_patch(state, {"set": {"items[9].name": "x"}})
+
+
+@pytest.mark.unit
+def test_index_into_non_list_rejected(state):
+    with pytest.raises(PatchError, match="requires a list"):
+        apply_patch(state, {"set": {"meta[0]": "x"}})
+
+
+# ── preview ───────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_preview_reports_changes_without_applying(state):
+    changes = preview_patch(
+        state, {"set": {"meta.retries": 0}, "delete": ["broken_field"]}
+    )
+    ops = {c.op: c for c in changes}
+    assert ops["set"].before == 3
+    assert ops["set"].after == 0
+    assert ops["set"].existed is True
+    assert ops["delete"].before == "PLACEHOLDER"
+    assert state["meta"]["retries"] == 3  # untouched
+
+
+@pytest.mark.unit
+def test_preview_surfaces_errors_as_a_dry_run(state):
+    with pytest.raises(PatchError):
+        preview_patch(state, {"set": {"meta.nonexistent": 1}})
+
+
+@pytest.mark.unit
+def test_format_changes_renders_all_three_shapes(state):
+    changes = preview_patch(
+        state,
+        {
+            "set": {"meta.retries": 0, "added": "new"},
+            "delete": ["broken_field"],
+        },
+        create_missing=True,
+    )
+    lines = format_changes(changes)
+    assert any(line.startswith("~ meta.retries") for line in lines)
+    assert any(line.startswith("+ added") for line in lines)
+    assert any(line.startswith("- broken_field") for line in lines)
+
+
+@pytest.mark.unit
+def test_format_changes_truncates_long_values():
+    state = {"blob": "x" * 500}
+    changes = preview_patch(state, {"set": {"blob": "y" * 500}})
+    line = format_changes(changes, max_value_chars=40)[0]
+    assert "…" in line
+    assert len(line) < 200
+
+
+@pytest.mark.unit
+def test_patch_handles_argus_signal_field_path_form():
+    """A dotted_path from a SemanticSignal should paste straight into a patch."""
+    state = {"result": {"items": [{"summary": "TODO: fill this in"}]}}
+    signal_path = "result.items.[0].summary"
+    out = apply_patch(state, {"set": {signal_path: "real summary"}})
+    assert out["result"]["items"][0]["summary"] == "real summary"


### PR DESCRIPTION
## What this adds

`ReplayEngine` already resumes a pipeline from any saved node, freezes upstream outputs, and replays recorded HTTP for determinism. The one thing missing was the ability to **change** the state before resuming — `replay()` deserialized `step.input_state` verbatim.

This PR adds that layer. A developer who spots a bad value at step 7 can now correct it and resume the remaining steps, instead of editing code and re-running all ten.

```bash
argus replay RUN_ID node_7 --set status=OK            # correct a value
argus replay RUN_ID node_7 --delete stale_field       # reproduce a dropped field
argus replay RUN_ID node_7 --patch fix.json           # a full patch document
argus replay RUN_ID node_7 --set status=OK --dry-run  # preview, run nothing
```

## Where this sits

Phase 1 of a step-by-step roadmap. Each step is a separate commit, small enough to review on its own.

| Step | Scope | Status |
|---|---|---|
| 1.1 | `state_patch.py` — pure patch layer. Touches no existing module | in this PR |
| 1.2 | `ReplayEngine` wiring + `RunRecord.state_patch` provenance | in this PR |
| 1.3 | `argus replay --set/--delete/--patch/--dry-run` + preview | in this PR |
| 1.4 | `/api/replay` accepts a patch (backend only) | in this PR |
| 1.5 | `/api/replay/preview` — dry run over HTTP | tracked follow-up |
| 1.6 | Frontend JSON editor in `ReplayControls.tsx` | tracked follow-up |
| 1.7 | Persist the run when a replay crashes (see below) | tracked follow-up |

Steps 1.5–1.7 are **tracked follow-ups, not omissions** — they are deliberately separate so this PR stays reviewable.

## Why this feature first

Patching a recorded state is the primitive underneath several other planned directions — injecting a malicious tool output for red-team testing, holding a field fixed to assert a downstream contract, and comparing trajectories under a changed input are all "run the graph from a mutated state." Building it once makes those additive rather than each inventing their own mechanism.

## Design decisions worth reviewing

- **Patch before deserialize.** The patch applies to the raw recorded dict, then `safe_deserialize` runs. Typed states (pydantic / dataclass / TypedDict) are therefore validated against the patched values rather than bypassing validation.
- **Fixed op order.** `delete` → `set` → `merge`, so results never depend on JSON key ordering. A path targeted by two op groups is rejected rather than silently resolved.
- **Strict by default.** A mistyped path raises with a `difflib` "did you mean" hint instead of silently adding a field; creating new keys requires `--create-missing`. In a debugging tool, a silently absorbed typo is worse than an error.
- **Path syntax matches existing signals.** Both `items[0].name` and `items.[0].name` parse identically, so the `field_path` ARGUS already reports on a failing signal pastes straight into a patch.
- **Provenance.** `RunRecord.state_patch` records the patch and round-trips through storage, so a patched replay explains its own divergence from its parent. Unpatched replays record `None`.
- **Fail before side effects.** A malformed patch raises before any node function is imported or executed — asserted by a test that checks no node ran. The same holds at the API layer: validation happens in the request handler, so a bad patch returns `400` with the hint rather than being accepted as a job and failing opaquely in a worker thread.
- **No new dependencies.**

## Testing

86 new tests (66 unit on the patch layer + CLI construction, 20 end-to-end on patched replay — 8 of which stand up the real dashboard handler on an ephemeral port and drive it over HTTP).

Coverage includes the patched trajectory, upstream freezing, provenance round-trip, immutability of the caller's state, and every rejection path.

- Full suite: **264 passed, 3 skipped** (baseline was 178 passed, 3 skipped)
- `ruff check .` — clean
- `mypy`: **164 errors before and after** — no new ones; `state_patch.py` itself is strict-clean
- Verified manually end to end through the `argus replay` CLI: preview, real patched replay, persistence, and each error path

Note: the `CI` workflow triggers only on PRs targeting `main`/`master`, so it does not run against this `dev`-targeted PR at all. The commands it would run (`ruff check .` and `pytest --tb=short`) were run locally and pass. Worth deciding separately whether `dev` should be added to that trigger list — nothing currently validates PRs into the active development branch.

## Noted, not changed — step 1.7

A node crash during replay propagates out of `_replay_direct` before `session.finalize()` is reached, so **no replay record is persisted for a crashing replay**. This is pre-existing behaviour, unrelated to patching.

It matters because "delete a field to reproduce the crash" is exactly the workflow that hits it — the reproduction currently surfaces as a raised exception with no saved forensic record. The fix is small (wrap the execution loop so finalize runs on the crash path) but it changes existing replay semantics, so it gets its own step and its own tests rather than widening this PR. The delete-op test documents current behaviour rather than asserting a record exists.