### PR TITLE
docs: roadmap backlog (good-to-have-dev) + "How We Work" process rule

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -122,6 +122,25 @@ For bug reports, include:
 - A minimal run output dict that reproduces the issue
 - What ARGUS reported vs what you expected
 
+## How We Work
+
+**Break work into small, trackable steps and do them one at a time.**
+
+Plan the whole thing first as numbered steps. Then execute one step at a time, stopping after each
+so the direction can be corrected before more work is built on top of it.
+
+- Don't chain steps together
+- Don't build a whole feature because the plan for it was agreed — **agreeing a plan is not
+  agreement to execute all of it at once**
+- Each step should be small enough to review in one sitting and land as its own commit
+- If a step turns out bigger than it looked, stop and re-split it rather than pushing through
+
+The point is that work stays steerable. A finished feature that went the wrong way three steps
+back costs more than the few check-ins it would have taken to catch it.
+
+**This applies to AI coding assistants too** — arguably more, since they will happily complete an
+entire roadmap in one pass. If you're using one on this repo, hold it to the same rule.
+
 ## Pull Requests
 
 - Keep PRs focused — one fix or feature per PR

--- a/good-to-have-dev/README.md
+++ b/good-to-have-dev/README.md
@@ -1,0 +1,53 @@
+# Good to have — dev
+
+Parked feature ideas for ARGUS, with an honest assessment of each.
+
+This folder exists because a long brainstorm produced a list of "ARGUS should build X" ideas, and
+a surprising number of them turned out to be **already built**. Rather than let that analysis
+evaporate into a chat log and get re-litigated in three months, each idea gets a short decision
+record here.
+
+## What each doc contains
+
+1. **The idea** — what was proposed, stated fairly
+2. **What already exists** — the specific modules in `src/argus/` that already do part of it
+3. **What's genuinely missing** — the real delta
+4. **Rough size** — honest effort estimate
+5. **Why it's parked** — what would need to be true to build it
+
+That third section is the point. Almost every proposal here is partially built already, and the
+difference between "build a blame attribution engine" and "add embedding-based drift scoring to
+`correlator.py`" is the difference between a quarter and an afternoon.
+
+## Current state
+
+| Idea | Status | Verdict |
+|---|---|---|
+| [Regression contracts](regression-contracts.md) | Not built | **Build next.** Needs a golden-trace tag first |
+| [Graph hazard linter](graph-hazard-linter.md) | Not built | **Cheapest standalone win.** No LLM, no deps |
+| [Live loop guard](live-loop-guard.md) | Half built | Post-hoc analysis exists; live guard is the delta |
+| [Smoke test runner](smoke-test-runner.md) | Not built | Gateway to graph-aware pass/fail and drift metrics |
+| [Indirect injection testing](indirect-injection-testing.md) | Not built | Strongest differentiator; primitive already exists |
+| [Flaky tool heatmap](flaky-tool-heatmap.md) | Not built | Data is already captured, just not aggregated |
+| [Dropped ideas](dropped-ideas.md) | — | Two proposals recommended **against** building |
+
+## Already shipped — do not re-propose
+
+These came up as "ARGUS should build this" and already exist:
+
+| Proposal | Where it lives |
+|---|---|
+| Resume execution from step N | `replay.py` — `ReplayEngine.replay()`, upstream outputs frozen |
+| Time-travel state patching | `state_patch.py` + `argus replay --set/--delete/--patch` |
+| Root-cause / blame attribution | `correlator.py` — `DegradationOrigin` with confidence scores |
+| Loop stall + wasted-retry detection | `loop_analyzer.py` (post-hoc) |
+| Behavioral diff between runs | `cmd_diff.py` + `ReplayComparisonResult` |
+| Deterministic replay of external calls | `http_recorder.py` — record/playback |
+| Custom per-node assertions | `validators={...}` on `ArgusWatcher` / `ArgusSession` |
+| Full step-by-step state capture | `NodeEvent.input_state` / `.output_dict` |
+
+## Promoting an idea out of this folder
+
+When one gets built: delete its doc in the implementing PR and link the PR from the table above.
+The folder should shrink over time. If a doc has been here a year untouched, that is information —
+either it is not actually important, or the "what's missing" section is wrong.

--- a/good-to-have-dev/dropped-ideas.md
+++ b/good-to-have-dev/dropped-ideas.md
@@ -1,0 +1,85 @@
+# Dropped ideas
+
+Proposals considered and **recommended against** — either already built, or a poor fit for what
+ARGUS is. Recorded here so they stop resurfacing.
+
+---
+
+## 1. "Build a Root-Cause Attribution Engine"
+
+**Verdict: already shipped. Do not rebuild.**
+
+The proposal: when a multi-agent system delivers a broken answer, trace backward through state
+history, find where quality dropped most, and report something like *"84% probability the failure
+originated in Researcher Agent at Step 3."*
+
+This is `correlator.py` — 805 lines, already in the product and already wired into every run.
+
+| Proposed capability | Where it already lives |
+|---|---|
+| Trace backward from a failure | `correlator.correlate(record)`, called from `session.finalize()` |
+| Identify the origin node | `DegradationOrigin(node_name, step_index, signal_types, confidence, reason)` |
+| Show how it spread | `PropagationChain` + `PropagationLink(source, target, signal_type, confidence, evidence)` |
+| Confidence score | `confidence: float` on both origins and links |
+| Clean summary instead of a log dump | `CorrelationReport.causal_summary`, a 1–3 sentence narrative |
+| Timeline of degradation | `TimelineEvent` with `degradation_onset` / `propagation` / `crash` markers |
+| LLM-augmented explanation | `llm_correlator.py` → `LLMCorrelationInsight` |
+
+The README has advertised this since before the proposal was written: *"Correlator — traces failure
+propagation across nodes. Points at the origin, not the crash site."*
+
+### The one genuine upgrade
+
+The proposal's distinctive detail — scoring **semantic drift of the state vector at every node
+transition** — is not implemented. The correlator reasons over discrete signals (dropped fields,
+tool failures, placeholder matches), not over continuous embedding distance between consecutive
+states.
+
+That is worth building, and it is cheap: `embedding_store.py` already provides
+`text-embedding-3-small` with a SQLite cache and cosine similarity. Embedding consecutive state
+snapshots and flagging the largest drop would add a genuinely new signal to
+`DegradationOrigin`.
+
+**But log it as an enhancement to `correlator.py`, not as a new feature.** The difference in scope
+is roughly a quarter versus an afternoon, and framing it as greenfield work is how a team ends up
+building a second correlator next to the first one.
+
+---
+
+## 2. RAG chunk-to-question generator (synthetic evaluation data)
+
+**Verdict: good idea, wrong product.**
+
+The proposal: generate synthetic test questions from RAG chunks at three difficulty tiers — direct,
+messy/typo-laden, and questions that implicitly contradict the chunk to test whether the agent
+catches the nuance or hallucinates.
+
+The critique attached to it is correct: naive chunk-to-question generation produces questions that
+match the source text too closely, so the agent passes the test and fails on real users. The
+"adversarial humanization" fix is a genuinely sharp insight.
+
+### Why it does not belong in ARGUS
+
+ARGUS is a **forensic recorder**. Every module in `src/argus/` operates on something that already
+happened: `session.py` captures execution, `storage.py` persists it, `correlator.py` explains it,
+`replay.py` re-runs it. The product's whole claim is fidelity about the past.
+
+A question generator produces *inputs that never existed*. It shares no data model with anything
+here — no `RunRecord`, no `NodeEvent`, no graph topology. It would be a separate codebase living
+in the same repo, sold to a different buyer (a RAG engineer building a dataset, not a platform
+engineer debugging a pipeline), competing with Ragas and DeepEval on their home ground.
+
+The strategic cost is worse than the engineering cost: ARGUS's differentiation is being the tool
+that catches silent failures in agent graphs. Adding a synthetic-data generator dilutes that into
+"another LLM eval platform", which is the crowded category the product is deliberately not in.
+
+### What to do instead
+
+If synthetic scenarios are wanted, the ARGUS-shaped version is to **derive them from recorded
+runs** rather than from source documents — take real recorded states and mutate them. That fits
+the existing data model exactly, and the primitive already exists: `state_patch.py` mutates a
+recorded state, and `session.frozen_outputs` substitutes tool responses. See
+[indirect-injection-testing.md](indirect-injection-testing.md), which uses precisely this approach
+for adversarial scenarios.
+
+Generating questions from chunks is a good product. It is someone else's.

--- a/good-to-have-dev/flaky-tool-heatmap.md
+++ b/good-to-have-dev/flaky-tool-heatmap.md
@@ -1,0 +1,48 @@
+# Flaky tool & API heatmap
+
+**Status:** not built · **Verdict:** cheap, data already captured · **Size:** small–medium
+
+## The idea
+
+Traditional APM shows how long a tool took. But agents fail because tools are flaky, rate-limited,
+or return unstructured garbage that breaks the parser. The interesting failure is the one where
+the API returns `200 OK` and the agent's JSON parser fails to read it 40% of the time.
+
+Track tool-to-LLM alignment and produce a heatmap of which tool schemas need rewriting.
+
+## What already exists
+
+The data collection is essentially done; the aggregation is not.
+
+- **Every HTTP call is already captured.** `http_recorder.py` records method, URL, request body
+  hash, and response for every outbound call, saved to `.argus/runs/<run-id>.http.json`. Status
+  codes and bodies are already on disk.
+- **Tool failures are already modelled.** `ToolFailure` (`models.py`) classifies
+  `error_response | rate_limit | empty_result | error_in_data | partial_failure` with severity and
+  evidence, attached to `InspectionResult.tool_failures`.
+- **Per-node timing and token cost** — `NodeEvent.duration_ms`, `llm_tracker.py`, `pricing.py`.
+- **Signature hit statistics across runs already exist.** `signature_stats.py` tracks hit metadata
+  and prunes stale signatures — an existing precedent for cross-run aggregation to follow.
+- **Anomaly detection** (`anomaly_detector.py`) already flags output-size and timing outliers.
+
+## What's genuinely missing
+
+1. **Cross-run aggregation of tool outcomes.** Everything above is per-run. The heatmap is
+   fundamentally "group by tool across the last N runs", and there is no such layer.
+2. **The 200-OK-but-unparseable correlation.** This is the actually novel bit: joining an HTTP
+   response that succeeded to a *downstream node failure* that followed it. The join key exists
+   (both are within a run, ordered by step) but nothing computes it.
+3. **A tool identity.** HTTP interactions are keyed by URL, node events by node name. Attributing
+   a call to a named tool requires a mapping that does not exist — the pragmatic first version
+   groups by URL host plus path prefix.
+4. **A visualization.** Heatmap in the dashboard.
+
+## Why it's parked
+
+Not blocked on anything — this is buildable today and is a good candidate right after the graph
+linter. It is parked mainly because (3) needs a design decision about what a "tool" is in ARGUS's
+model, and getting that wrong makes the aggregation meaningless.
+
+Worth noting the strategic value: it is the one idea in this folder that produces insight from
+data ARGUS is *already collecting and currently throwing away* at the end of each run. The cost is
+aggregation, not instrumentation.

--- a/good-to-have-dev/graph-hazard-linter.md
+++ b/good-to-have-dev/graph-hazard-linter.md
@@ -1,0 +1,55 @@
+# Graph hazard linter (static analysis for agent graphs)
+
+**Status:** not built · **Verdict:** cheapest standalone win · **Size:** small (~2–4 days)
+
+## The idea
+
+SAST, but for graph topology. Before a single token is spent, scan the graph structure and flag
+architectural hazards:
+
+- **Dead ends** — nodes that consume state but never pass it forward
+- **Unbounded cycles** — loops with no explicit exit condition
+- **State collisions** — parallel nodes writing the same state key
+- **Unreachable nodes** — present in the graph, never on any path from entry
+
+A linter for multi-agent systems, catching structural failures before runtime.
+
+## What already exists
+
+- **The topology is already extracted.** `patcher.extract_edge_map(graph)` builds
+  `{source: [dest]}` and already handles the hard cases: standard edges, LangGraph ≥0.2
+  `branches` with `BranchSpec.ends`, and legacy `_conditional_edges`. This is the input the
+  linter needs and it is done.
+- **Cycle detection exists.** `utils/cycle_detection.py`, used to set `RunRecord.is_cyclic` and to
+  warn when a cyclic graph is garbage-collected without `finalize()` (`watcher.py:102`).
+- **The edge map is persisted per run.** `RunRecord.graph_edge_map`, so hazards can be reported
+  against a recorded run as well as a live graph.
+- **Node type hints are already introspected.** `utils/type_introspection.py` and
+  `inspector.py` read successor annotations — the same machinery that would detect state-key
+  collisions between parallel branches.
+
+## What's genuinely missing
+
+The analysis pass itself. Given `graph_edge_map`, each check is a straightforward graph algorithm:
+
+- Dead end → node with no outgoing edges that is not a designated terminal
+- Unreachable → not in the transitive closure from the entry node
+- Unbounded cycle → strongly-connected component with no edge leaving it toward a terminal
+- State collision → needs write-key inference per node, the only genuinely hard one; the honest
+  first version reads type hints and return annotations and skips nodes it cannot analyze
+
+Plus a CLI surface (`argus lint`) and a non-zero exit for CI.
+
+## Why it's parked
+
+Not because it is hard — it is the cheapest thing on this list, needs no LLM, no new dependencies,
+and no changes to any existing code path. It is parked because it is **orthogonal to ARGUS's core
+loop**: everything else in the product reasons about recorded runs, and this reasons about a graph
+that has not run yet.
+
+That makes it an excellent standalone contribution, and a good first task for someone new to the
+codebase. It is genuinely differentiated — no competitor lints graph topology.
+
+Caveat worth designing around: static analysis of a dynamic graph will produce false positives
+(conditional edges resolved at runtime, nodes added programmatically). Ship it as advisory output
+first, and only add a CI-failing mode once the false-positive rate is known.

--- a/good-to-have-dev/indirect-injection-testing.md
+++ b/good-to-have-dev/indirect-injection-testing.md
@@ -1,0 +1,58 @@
+# Indirect prompt injection & tool hijack testing
+
+**Status:** not built · **Verdict:** strongest differentiator · **Size:** medium
+
+## The idea
+
+Most LLM security testing treats the agent as a chat box: inject "ignore previous instructions"
+into the user prompt and see what happens. But an agent is a network of tools, and the dangerous
+payload usually is not typed by the user — it is *fetched*.
+
+The scenario: the agent uses a tool to read a webpage. The page contains hidden text saying
+"delete the user account." Does the agent execute an instruction it found in tool output?
+
+Simulating malicious *tool returns* — data-plane injection, not prompt-plane — is something no
+observability tool on the market does.
+
+## What already exists
+
+The injection primitive is already built, for a completely different reason.
+
+- **`session.frozen_outputs`** (`session.py:260`, popped in `_pop_frozen_output`) substitutes a
+  recorded output for a node instead of calling it. It exists to freeze upstream nodes during
+  replay — but "return this payload instead of calling the real function" is exactly a mock tool
+  response. Feeding it an adversarial payload rather than a recorded one is a change of intent,
+  not of mechanism.
+- **`http_recorder.py`** intercepts outbound HTTP at the `urllib3` layer, underneath `requests`
+  and `httpx`. `playback_http()` already serves canned responses. Injecting a malicious HTTP
+  *response body* needs no new interception machinery.
+- **State patching** (`state_patch.py`) can now place an arbitrary payload into any field of a
+  recorded state before resuming — a third injection surface, already shipped.
+- **Detection partially exists.** `heuristic_engine.py` and the 150+ signature registry
+  (`registry.py`) already scan outputs for degradation patterns; `ToolFailure` models tool-level
+  problems.
+
+## What's genuinely missing
+
+1. **A payload corpus** — known indirect-injection patterns, versioned and updatable.
+2. **A harness** that runs a pipeline once per payload and records what the agent did. This is the
+   dependency on [smoke-test-runner.md](smoke-test-runner.md).
+3. **A judgement layer** — the hard part. Detecting that the agent *complied* with an injected
+   instruction is not pattern matching on the output; it requires knowing which tool calls were
+   attempted and whether any was attributable to injected text rather than user intent.
+   `llm_tracker.py` records LLM calls, but there is no tool-call intent record today.
+4. **A report** that distinguishes "agent ignored it" / "agent repeated it" / "agent acted on it".
+   Only the third is a real vulnerability, and conflating them produces noise.
+
+## Why it's parked
+
+It depends on the smoke runner, and (3) is genuinely unsolved rather than merely unbuilt.
+
+It is worth flagging as the highest-*value* item here even though it is not the highest-*priority*.
+"The only observability tool that tests for data-plane prompt injection" is a stronger market
+claim than anything else in this folder, and security review is a hard gate on agents touching
+production systems.
+
+One caution: this feature involves generating and storing adversarial payloads. Keep the corpus
+clearly scoped to defensive testing of the user's own pipelines, and keep payloads inert as data
+(never executed by ARGUS itself).

--- a/good-to-have-dev/live-loop-guard.md
+++ b/good-to-have-dev/live-loop-guard.md
@@ -1,0 +1,60 @@
+# Live loop guard (loop detonator)
+
+**Status:** half built · **Verdict:** real delta, but handle with care · **Size:** small–medium
+
+## The idea
+
+Agents caught in an existential loop (A asks B, B asks A) burn thousands of dollars in tokens.
+Rather than a crude `max_iterations = 10`, analyze *state trajectory*: if the similarity of the
+last three state transitions exceeds ~0.95, halt execution, alert the pipeline, and show a loop
+visualization.
+
+## What already exists
+
+More than the pitch assumes.
+
+- **Loop analysis is already shipped** — `loop_analyzer.py` runs mandatory LLM analysis on every
+  looped node, producing `LoopAnalysisResult` with `is_stalled`, `stall_details`,
+  `unnecessary_retries`, and per-iteration diffs. The README documents "Loop stalls" and
+  "Unnecessary retries" as things ARGUS already catches.
+- **Iteration tracking is live during the run.** `session.py` maintains `attempt_index` per node
+  event and sets `total_iterations` on finalize. The counter the guard needs is already there.
+- **Cyclic graphs are detected up front** — `utils/cycle_detection.py`, `RunRecord.is_cyclic`.
+- **Embedding + cosine similarity infrastructure exists.** `embedding_store.py` wraps
+  `text-embedding-3-small` with a SQLite cache, batch computation, and similarity — the exact
+  primitive the "0.95 similarity" proposal needs. `tests/test_semantic_similarity.py` covers it.
+
+## What's genuinely missing
+
+**Timing.** `loop_analyzer.py` runs *post-hoc*, at finalize, after the tokens are already spent.
+It tells you that you burned $40 in a loop. It does not stop you burning it.
+
+The delta is a guard inside the wrapper — `session.py`, `_make_sync_wrapper` /
+`_make_async_wrapper`, where `attempt_index` is already tracked. On each iteration past a
+threshold, embed the state delta and compare against the previous N iterations. On stagnation,
+act.
+
+Also missing: the loop visualization map.
+
+## Why it's parked
+
+Because "act" is a dangerous verb, and the pitch's framing — *halt execution* — is the wrong
+default.
+
+ARGUS's whole promise is that it is a passive observer you can wrap around a pipeline without
+changing its behavior. A monitoring tool that kills a production run because a similarity heuristic
+crossed 0.95 will eventually kill a legitimate one — a retry loop that genuinely needs six
+near-identical attempts before converging, for instance. The first time that happens in
+production, ARGUS gets removed from the stack.
+
+Recommended design if built:
+
+1. **Default to warn.** Log loudly, record a signal, do not interrupt. Halting is opt-in.
+2. **Cost-aware, not just similarity-aware.** `llm_tracker.py` and `pricing.py` already compute
+   per-call cost. "You have spent $12 on a loop showing no state progress" is more actionable, and
+   far safer, than a bare similarity number.
+3. **Embedding calls cost money too.** Embedding every iteration of every looped node adds spend to
+   a feature whose purpose is reducing spend. Gate it behind an iteration threshold and reuse the
+   `embedding_store.py` cache.
+4. **Separate the two audiences.** In CI, halting is correct and cheap. In production, warning is
+   correct. The config should make that distinction explicit rather than picking one.

--- a/good-to-have-dev/regression-contracts.md
+++ b/good-to-have-dev/regression-contracts.md
@@ -1,0 +1,50 @@
+# Auto-generated regression contracts
+
+**Status:** not built · **Verdict:** build next · **Size:** medium (~1–2 weeks)
+
+## The idea
+
+Tag a successful run as a "golden trace". ARGUS parses it and learns a structural contract for
+every node — this node always returns three keys, this field is always a non-empty list, this node
+is always reached. On the next pre-deployment pass, a prompt change that makes the agent skip a
+node or return a different shape fails the build.
+
+The pitch: nobody wants to hand-write assertions for every node transition in a graph. Learned
+assertions beat written ones.
+
+## What already exists
+
+- **Every input and output is already recorded.** `NodeEvent.input_state` and
+  `NodeEvent.output_dict` (`models.py`) hold the full state per step. A contract can be *derived*
+  from a stored run — no new instrumentation needed.
+- **Type-level contract checking already runs.** `inspector.py` has `inspect_transition`, which
+  reads successor type annotations and reports `FieldMismatch` when output types do not match the
+  next node's expected input. `InspectionResult.type_mismatches` carries the result.
+- **Manual assertions exist.** `validators={"node": lambda o: (bool, msg)}` covers the
+  hand-written case, which is exactly what this feature aims to replace.
+- **Run persistence and reload is solved.** `storage.save_run` / `load_run`, with schema
+  versioning (`schema_version`) and a deserialization fallback already in place.
+
+## What's genuinely missing
+
+1. **A golden-trace tag.** No concept of marking a run as the reference. Needs a field on
+   `RunRecord` (or a sidecar file in `.argus/`), a CLI verb, and a UI affordance.
+2. **A contract inference pass.** Walk a golden run and emit, per node: key set, per-field type,
+   emptiness, list lengths where stable, and which nodes were reached in what order. The
+   interesting design question is which observations generalize from a single run and which are
+   coincidence — inferring from N golden runs is far more defensible than from one.
+3. **A contract checker.** Compare a new run against the stored contract, emit violations.
+4. **A non-zero exit path for CI.** ARGUS has no "fail the build" mode today.
+
+## Why it's parked
+
+Only because state patching came first — this is the strongest of the parked ideas.
+
+The thing to get right is (2). Inferring a contract from exactly one run will produce brittle
+assertions that fail on harmless variation, and a testing tool that cries wolf gets turned off.
+Recommend requiring several golden runs before a field is promoted to a hard assertion, and
+distinguishing "always observed" from "observed once".
+
+Note the prerequisite ordering: the golden-trace tag from (1) is also what
+[smoke-test-runner.md](smoke-test-runner.md) needs for its expected-output baseline. Build it once,
+in a shape that serves both.

--- a/good-to-have-dev/smoke-test-runner.md
+++ b/good-to-have-dev/smoke-test-runner.md
@@ -1,0 +1,53 @@
+# Smoke test runner (graph-aware pass/fail)
+
+**Status:** not built · **Verdict:** gateway feature · **Size:** large
+
+## The idea
+
+Run a dataset of scenarios against a pipeline and report pass/fail — but *graph-aware*. Not
+"80% passed", but: "10 scenarios failed; in 90% of them the agent took the Refund route instead
+of Escalation. The issue is localized to Node X."
+
+Linking test results back to graph topology is the differentiator; plain pass/fail percentages are
+a commodity (Promptfoo, DeepEval).
+
+## What already exists
+
+- **Per-run pass/fail already exists at node granularity.** `NodeEvent.status` is one of
+  `pass | fail | crashed | degraded_input | semantic_fail | interrupted | retried`, and
+  `RunRecord.overall_status` aggregates it.
+- **Path data is already recorded.** `RunRecord.steps` in execution order plus
+  `graph_edge_map` means the actual route through the graph is fully reconstructable per run —
+  this is precisely the data the "which route did it take" analysis needs, and it is already
+  persisted.
+- **Failure localization already exists.** `correlator.py` produces `DegradationOrigin` with a
+  confidence score and `PropagationChain`. The "localized to Node X" claim is largely a
+  cross-run aggregation of something ARGUS already computes per run.
+- **Cross-run comparison exists** for pairs — `cmd_diff.py`, `ReplayComparisonResult`.
+- **Run listing and storage** — `storage.list_runs`, `build_replay_tree`.
+
+## What's genuinely missing
+
+1. **A dataset concept.** No notion of a scenario set. Needs a format, a loader, and a place to
+   live in `.argus/`.
+2. **A runner.** Execute N scenarios against a pipeline, ideally in parallel. The natural shape is
+   `asyncio` — `session.wrap()` already handles async node functions via `_make_async_wrapper`,
+   so async pipelines are supported; the missing piece is concurrency *across* runs, and the
+   concern there is that `ArgusSession` state and the `.argus/runs/` writes must stay isolated
+   per scenario.
+3. **Cross-run aggregation.** Everything today is per-run or pairwise. Route-frequency analysis
+   ("90% of failures took this path") needs an N-run aggregation layer that does not exist.
+4. **CI surface.** A non-zero exit and a machine-readable report.
+
+## Why it's parked
+
+Size, and ordering. This is the largest item in this folder, and two of its dependencies are
+cheaper to build first:
+
+- It wants a **baseline** to compare against — that is the golden-trace tag from
+  [regression-contracts.md](regression-contracts.md).
+- It is the **prerequisite** for the drift metrics ("tool utilization dropped 14%") and for
+  [indirect-injection-testing.md](indirect-injection-testing.md), which needs a harness to run
+  many adversarial scenarios.
+
+Build golden traces first, then this, then injection testing on top.


### PR DESCRIPTION
## What this is

Documentation only. No source file is touched.

Two related things: a set of decision records for parked feature ideas, and the process convention that governs how we work through them.

## 1. `good-to-have-dev/` — decision records

A long brainstorm produced a list of "ARGUS should build X" proposals. Checking each against `src/argus/` turned up two things worth writing down:

1. **A surprising number are already built.** The proposal to "build a Root-Cause Attribution Engine" describes `correlator.py`, which has shipped for a while. "Resume execution from step N" is `ReplayEngine.replay()`. "Behavioral trajectory diffing" is `cmd_diff.py`.
2. **Several of the rest are much smaller than proposed**, because the groundwork exists. The live loop guard needs an embedding comparison, and `embedding_store.py` already provides cached `text-embedding-3-small` similarity.

Every doc follows the same shape:

> the idea, stated fairly → **what already exists** (with file paths) → **what's genuinely missing** → rough size → why it's parked

The third section is the point. The gap between "build a blame attribution engine" and "add embedding drift scoring to `correlator.py`" is a quarter versus an afternoon, and the original proposals couldn't see that distinction because they were written from the pitch rather than the code.

These map onto a phased roadmap, so the folder is a **backlog with an order**, not a loose idea dump:

| Doc | Roadmap phase | Verdict |
|---|---|---|
| `regression-contracts.md` | Phase 2 | **Build next.** Needs a golden-trace tag first, which Phase 6 also depends on |
| `graph-hazard-linter.md` | Phase 3 | **Cheapest standalone win.** Pure graph algorithms over `patcher.extract_edge_map()`. No LLM, no new deps |
| `live-loop-guard.md` | Phase 4 | Half exists — `loop_analyzer.py` is post-hoc. Argues the live version **must default to warn, not kill** |
| `flaky-tool-heatmap.md` | Phase 5 | Data already captured by `http_recorder.py` and discarded at end of run. Needs aggregation, not instrumentation |
| `smoke-test-runner.md` | Phase 6 | Largest; gateway to drift metrics and injection testing |
| `indirect-injection-testing.md` | Phase 7 | Highest *value*, lowest priority. `session.frozen_outputs` is already a working injection primitive |

### Argued against

`dropped-ideas.md` covers two proposals recommended **not** to build:

- **Rebuilding a blame attribution engine.** `correlator.py` already ships it — `DegradationOrigin` with confidence scores, `PropagationChain`, `TimelineEvent`, plus LLM augmentation in `llm_correlator.py`. The doc maps each proposed capability to where it already lives. The one genuine upgrade is embedding-based drift scoring per transition, logged as an enhancement to that module — specifically so nobody builds a second correlator next to the first.
- **RAG chunk-to-question generation.** A data-generation product, not a tracing one. No shared data model, different buyer, competes with Ragas on their home ground. The "adversarial humanization" insight behind it is genuinely sharp — it just belongs in someone else's tool. The doc suggests the ARGUS-shaped alternative: mutate *recorded* states, which `state_patch.py` (PR #29) now does.

`README.md` also carries an **"already shipped — do not re-propose"** table covering replay-from-node, state patching, blame attribution, loop analysis, behavioral diffing, HTTP determinism, custom validators, and full state capture — each with the module it lives in. Plus how ideas leave the folder: when one is built, its doc is deleted in the implementing PR.

## 2. `CONTRIBUTING.md` — "How We Work"

A short section recording that work is planned as numbered steps and executed one step at a time, stopping after each so direction can be corrected.

It's written down because the opposite happened here: a plan of three parts was agreed, and all three shipped in one pass along with two PRs, leaving no point to adjust course. The section calls out AI coding assistants specifically, since they will otherwise complete an entire roadmap in a single pass.

**Placement note:** this went in `CONTRIBUTING.md` rather than a `CLAUDE.md`, because `.gitignore` deliberately treats `CLAUDE.md` as a local settings file alongside `.claude/`. Committing one would have reversed that choice.

## Naming

The folder is `good-to-have-dev` rather than the literally requested `good to have dev` — spaces in a repo path break shell globs and tooling. Trivial to rename if the literal spelling is preferred.

## Verification

Docs only. `ruff check .` clean and the suite passes unchanged (178 passed / 3 skipped on this branch, which is cut from `dev` and deliberately contains none of the state-patching code from #29).