### PR TITLE
feat: add double-encoded json detection (rule 17)

### DIFF
--- a/src/argus/fix_prompt.py
+++ b/src/argus/fix_prompt.py
@@ -63,7 +63,10 @@ _TOOL_FAILURE_PLAIN = {
     "empty_result": "the external call returned an empty result",
     "error_in_data": "the data that came back contained an error payload",
     "partial_failure": "the external call only partly succeeded",
-    "json_in_string": "the output contained a double-encoded stringified JSON object/array instead of a parsed structure",
+    "json_in_string": (
+        "the output contained a double-encoded stringified JSON object/array "
+        "instead of a parsed structure"
+    ),
 }
 
 # Present tense, for the "Done when" conditions — the past-tense phrasings above
@@ -74,7 +77,10 @@ _TOOL_FAILURE_CONDITION = {
     "empty_result": "the external call returns an empty result",
     "error_in_data": "the data that comes back contains an error payload",
     "partial_failure": "the external call only partly succeeds",
-    "json_in_string": "the output contains a double-encoded stringified JSON object/array instead of a parsed structure",
+    "json_in_string": (
+        "the output contains a double-encoded stringified JSON object/array "
+        "instead of a parsed structure"
+    ),
 }
 
 

--- a/src/argus/fix_prompt.py
+++ b/src/argus/fix_prompt.py
@@ -63,6 +63,7 @@ _TOOL_FAILURE_PLAIN = {
     "empty_result": "the external call returned an empty result",
     "error_in_data": "the data that came back contained an error payload",
     "partial_failure": "the external call only partly succeeded",
+    "json_in_string": "the output contained a double-encoded stringified JSON object/array instead of a parsed structure",
 }
 
 # Present tense, for the "Done when" conditions — the past-tense phrasings above
@@ -73,6 +74,7 @@ _TOOL_FAILURE_CONDITION = {
     "empty_result": "the external call returns an empty result",
     "error_in_data": "the data that comes back contains an error payload",
     "partial_failure": "the external call only partly succeeds",
+    "json_in_string": "the output contains a double-encoded stringified JSON object/array instead of a parsed structure",
 }
 
 

--- a/src/argus/inspector.py
+++ b/src/argus/inspector.py
@@ -413,7 +413,15 @@ def _scan_payload_for_tool_failures(
                 _scan_payload_for_tool_failures(item, item_path, depth + 1, add)
 
 
-_JSON_EXPECTED_KEYS = frozenset({"raw_response", "log", "logs", "raw", "history", "raw_output", "payload"})
+_JSON_EXPECTED_KEYS = frozenset({
+    "raw_response",
+    "log",
+    "logs",
+    "raw",
+    "history",
+    "raw_output",
+    "payload",
+})
 
 def _scan_double_encoded(
     obj: Any,

--- a/src/argus/inspector.py
+++ b/src/argus/inspector.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import re
 from difflib import SequenceMatcher
 from statistics import median
@@ -412,6 +413,49 @@ def _scan_payload_for_tool_failures(
                 _scan_payload_for_tool_failures(item, item_path, depth + 1, add)
 
 
+_JSON_EXPECTED_KEYS = frozenset({"raw_response", "log", "logs", "raw", "history", "raw_output", "payload"})
+
+def _scan_double_encoded(
+    obj: Any,
+    prefix: str,
+    depth: int,
+    add: Any,
+) -> None:
+    """Recursively scan dict/list payloads for double-encoded JSON strings (Rule 17)."""
+    if depth > 5:
+        return
+    if isinstance(obj, dict):
+        for key, value in obj.items():
+            if str(key).lower() in _JSON_EXPECTED_KEYS:
+                continue
+            field_path = f"{prefix}.{key}" if prefix else str(key)
+            if isinstance(value, str):
+                stripped = value.lstrip()
+                if stripped.startswith("{") or stripped.startswith("["):
+                    try:
+                        parsed = json.loads(stripped)
+                        if isinstance(parsed, (dict, list)):
+                            add(
+                                ToolFailure(
+                                    failure_type="json_in_string",
+                                    field_name=field_path,
+                                    severity="warning",
+                                    evidence=f"double-encoded JSON detected: {stripped[:80]!r}",
+                                )
+                            )
+                    except json.JSONDecodeError:
+                        pass
+            elif isinstance(value, dict):
+                _scan_double_encoded(value, field_path, depth + 1, add)
+            elif isinstance(value, list):
+                _scan_double_encoded(value, field_path, depth + 1, add)
+    elif isinstance(obj, list):
+        for i, item in enumerate(obj):
+            if isinstance(item, (dict, list)):
+                item_path = f"{prefix}[{i}]"
+                _scan_double_encoded(item, item_path, depth + 1, add)
+
+
 def is_legitimate_field_handoff(
     input_state: dict[str, Any] | None,
     output_dict: dict[str, Any] | None,
@@ -473,6 +517,9 @@ def inspect_tool_outputs(
     # Rules 1–6 — recursive tool-failure shapes (error keys, HTTP status,
     # success/failure booleans, empty retrieval, nested dict/list payloads)
     _scan_payload_for_tool_failures(output_dict, "", 0, _add)
+
+    # Rule 17 — Double-Encoded JSON Detection
+    _scan_double_encoded(output_dict, "", 0, _add)
 
     # Rule 7 — deep recursive semantic heuristic scan
     # Use pre-computed signals if available (avoids double-scan)

--- a/src/argus/inspector.py
+++ b/src/argus/inspector.py
@@ -423,6 +423,7 @@ _JSON_EXPECTED_KEYS = frozenset({
     "payload",
 })
 
+
 def _scan_double_encoded(
     obj: Any,
     prefix: str,
@@ -443,12 +444,13 @@ def _scan_double_encoded(
                     try:
                         parsed = json.loads(stripped)
                         if isinstance(parsed, (dict, list)):
+                            evidence_val = stripped[:80] + ("..." if len(stripped) > 80 else "")
                             add(
                                 ToolFailure(
                                     failure_type="json_in_string",
                                     field_name=field_path,
                                     severity="warning",
-                                    evidence=f"double-encoded JSON detected: {stripped[:80]!r}",
+                                    evidence=f"double-encoded JSON detected: {evidence_val!r}",
                                 )
                             )
                     except json.JSONDecodeError:

--- a/tests/test_inspector_unit.py
+++ b/tests/test_inspector_unit.py
@@ -629,13 +629,25 @@ class TestRule16ContextOverflow:
 @pytest.mark.unit
 class TestRule17JsonInString:
     def test_stringified_dict(self):
-        result = inspect_tool_outputs({"data": '{"key": "val"}'}, _precomputed_signals=[])
-        assert any(tf.failure_type == "json_in_string" for tf in result.tool_failures)
-        assert any(tf.severity == "warning" for tf in result.tool_failures if tf.failure_type == "json_in_string")
+        result = inspect_tool_outputs(
+            {"data": '{"key": "val"}'}, _precomputed_signals=[]
+        )
+        assert any(
+            tf.failure_type == "json_in_string" for tf in result.tool_failures
+        )
+        assert any(
+            tf.severity == "warning"
+            for tf in result.tool_failures
+            if tf.failure_type == "json_in_string"
+        )
 
     def test_stringified_list(self):
-        result = inspect_tool_outputs({"data": '[1, 2, 3]'}, _precomputed_signals=[])
-        assert any(tf.failure_type == "json_in_string" for tf in result.tool_failures)
+        result = inspect_tool_outputs(
+            {"data": '[1, 2, 3]'}, _precomputed_signals=[]
+        )
+        assert any(
+            tf.failure_type == "json_in_string" for tf in result.tool_failures
+        )
 
     def test_expected_skipped_fields(self):
         result = inspect_tool_outputs({
@@ -651,11 +663,24 @@ class TestRule17JsonInString:
         assert not any(tf.failure_type == "json_in_string" for tf in result.tool_failures)
 
     def test_nested_structure(self):
-        result = inspect_tool_outputs({"outer": {"inner": '{"key": "val"}'}}, _precomputed_signals=[])
-        assert any(tf.failure_type == "json_in_string" and tf.field_name == "outer.inner" for tf in result.tool_failures)
+        result = inspect_tool_outputs(
+            {"outer": {"inner": '{"key": "val"}'}}, _precomputed_signals=[]
+        )
+        assert any(
+            tf.failure_type == "json_in_string"
+            and tf.field_name == "outer.inner"
+            for tf in result.tool_failures
+        )
 
-        result2 = inspect_tool_outputs({"outer_list": [{'nested': '{"key": "val"}'}]}, _precomputed_signals=[])
-        assert any(tf.failure_type == "json_in_string" and tf.field_name == "outer_list[0].nested" for tf in result2.tool_failures)
+        result2 = inspect_tool_outputs(
+            {"outer_list": [{"nested": '{"key": "val"}'}]},
+            _precomputed_signals=[],
+        )
+        assert any(
+            tf.failure_type == "json_in_string"
+            and tf.field_name == "outer_list[0].nested"
+            for tf in result2.tool_failures
+        )
 
     def test_non_json_string_ignored(self):
         result = inspect_tool_outputs({"data": "just a normal string"}, _precomputed_signals=[])
@@ -664,6 +689,8 @@ class TestRule17JsonInString:
     def test_malformed_json_ignored(self):
         result = inspect_tool_outputs({"data": '{"key": "value"'}, _precomputed_signals=[])
         assert not any(tf.failure_type == "json_in_string" for tf in result.tool_failures)
+
+
 # ── Strict mode ──────────────────────────────────────────────────────────────
 
 

--- a/tests/test_inspector_unit.py
+++ b/tests/test_inspector_unit.py
@@ -622,6 +622,48 @@ class TestRule16ContextOverflow:
         assert any(tf.failure_type == "context_size_anomaly" for tf in result.tool_failures)
 
 
+
+# ── Rule 17: Double-encoded JSON ─────────────────────────────────────────────
+
+
+@pytest.mark.unit
+class TestRule17JsonInString:
+    def test_stringified_dict(self):
+        result = inspect_tool_outputs({"data": '{"key": "val"}'}, _precomputed_signals=[])
+        assert any(tf.failure_type == "json_in_string" for tf in result.tool_failures)
+        assert any(tf.severity == "warning" for tf in result.tool_failures if tf.failure_type == "json_in_string")
+
+    def test_stringified_list(self):
+        result = inspect_tool_outputs({"data": '[1, 2, 3]'}, _precomputed_signals=[])
+        assert any(tf.failure_type == "json_in_string" for tf in result.tool_failures)
+
+    def test_expected_skipped_fields(self):
+        result = inspect_tool_outputs({
+            "raw_response": '{"key": "val"}',
+            "log": '[1, 2, 3]',
+            "logs": '{"a": 1}',
+            "raw": '{"x": 2}',
+            "history": '[]',
+            "raw_output": '{}',
+            "payload": '{"key": "val"}',
+            "PAYLOAD": '{"key": "val"}'
+        }, _precomputed_signals=[])
+        assert not any(tf.failure_type == "json_in_string" for tf in result.tool_failures)
+
+    def test_nested_structure(self):
+        result = inspect_tool_outputs({"outer": {"inner": '{"key": "val"}'}}, _precomputed_signals=[])
+        assert any(tf.failure_type == "json_in_string" and tf.field_name == "outer.inner" for tf in result.tool_failures)
+
+        result2 = inspect_tool_outputs({"outer_list": [{'nested': '{"key": "val"}'}]}, _precomputed_signals=[])
+        assert any(tf.failure_type == "json_in_string" and tf.field_name == "outer_list[0].nested" for tf in result2.tool_failures)
+
+    def test_non_json_string_ignored(self):
+        result = inspect_tool_outputs({"data": "just a normal string"}, _precomputed_signals=[])
+        assert not any(tf.failure_type == "json_in_string" for tf in result.tool_failures)
+
+    def test_malformed_json_ignored(self):
+        result = inspect_tool_outputs({"data": '{"key": "value"'}, _precomputed_signals=[])
+        assert not any(tf.failure_type == "json_in_string" for tf in result.tool_failures)
 # ── Strict mode ──────────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
Solves #26 
Overview

**This PR implements Rule 17**: Double-Encoded JSON Detection in the ARGUS monitoring engine. It detects silent failures where a pipeline node returns a stringified JSON object or array (e.g. {"data": "{\"key\": \"value\"}"}) instead of a parsed Python dictionary or list structure. Double-encoded JSON is a common silent failure pattern that can trigger unexpected type mismatches, downstream parsing crashes, or silent data loss.

Proposed Changes
**1. Core Monitoring & Inspection**
src/argus/inspector.py
Helper function _scan_double_encoded: Added a recursive scanner (max depth 5) that checks string values to see if they start with { or [ (ignoring leading whitespace). If a string parses successfully into a dict or list using json.loads, a ToolFailure with type json_in_string and warning severity is registered.
Skipped Fields: Configured _JSON_EXPECTED_KEYS = {"raw_response", "log", "logs", "raw", "history", "raw_output", "payload"} (case-insensitive) to skip fields where stringified JSON payloads are expected.
Integration: Integrated the scanner into inspect_tool_outputs.

**2. Fix Prompt Jargon Translation**
src/argus/fix_prompt.py
Mapped "json_in_string" in both _TOOL_FAILURE_PLAIN and _TOOL_FAILURE_CONDITION to translate the internal failure enum into clear, jargon-free explanations for code generation agents:
Plain description: "the output contained a double-encoded stringified JSON object/array instead of a parsed structure"
Condition description: "the output contains a double-encoded stringified JSON object/array instead of a parsed structure"

**3. Testing**
tests/test_inspector_unit.py
Added the TestRule17JsonInString test class to verify all aspects of the new detection rule, testing:
Stringified dictionary inputs.
Stringified list inputs.
Case-insensitive field skipping on raw/payload fields.
Recursive validation on nested objects/arrays.
Safely ignoring non-JSON strings and malformed JSON strings without raising errors.
Verification Results
Automated Unit Tests
Executed the test suite inside the virtual environment:

bash
.venv/bin/pytest tests/test_inspector_unit.py
Results:

98 tests passed (including all 6 newly added test cases for Rule 17).