### PR TITLE
docs: document empty_output failure and per-invoke persistence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.9.4 — 2026-08-25
+
+- `empty_output` failure: a node returning a literal `{}` with successors downstream is flagged critical and blamed on the origin, not the downstream crash site — fixes silent no-op nodes (#31). Only literal `{}` is flagged; dicts with keys (even empty-valued) and router/conditional nodes are exempt
+- Per-invoke persistence: an attached `ArgusWatcher` now writes a separate run record for every `invoke()` / `stream()` / `batch()`, not just the first (via `ArgusSession.begin_new_run()`)
+
 ## 0.9.3 — 2026-08-18
 
 - `argus check last` / `argus check <id>` — CI gate; exit 1 on crash, silent failure, semantic fail, missing fields, or tool failures

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,7 @@ ARGUS is a production readiness platform for AI agent pipelines — detects sile
 
 Every wrapped node executes through this pipeline:
 1. Output captured and serialized
-2. **Tool failure scan** (`inspector.py`): error keys, HTTP status codes, empty results, semantic registry
+2. **Tool failure scan** (`inspector.py`): error keys, HTTP status codes, empty results, semantic registry. Also `empty_output` (critical): a node returning a literal empty state update (`{}`) while successors wait downstream — the canonical silent no-op, blamed on the origin instead of the downstream crash site. Narrow by design: only literal `{}` is flagged; a dict with keys (even empty-valued, e.g. `{"vulnerabilities": []}`) is a real state contribution left to the per-field rules, and router/conditional nodes (`successor_fns=[]`) are exempt.
 3. **Structural inspection** (`inspector.py`): missing required fields vs successor type hints, type mismatches
 4. **Semantic validators**: custom per-node or wildcard validators
 5. **Anomaly detection**: behavioral anomaly signals (output size, timing, structure)
@@ -103,6 +103,8 @@ All LLM chat completion calls route through `llm_proxy.create_chat_completion`. 
 ### Storage
 
 Runs are stored in `.argus/runs/<run-id>.json` relative to the working directory. Cloud sync to Supabase (non-blocking background thread) if the user is logged in via `argus login`.
+
+An attached `ArgusWatcher` reuses one `ArgusSession` across calls (its node wrappers close over it). Each outermost `invoke()` / `stream()` / `batch()` on an already-completed session calls `ArgusSession.begin_new_run()` to persist its own `RunRecord` (and re-arm the HTTP recorder) — so every invoke gets a run, not just the first. Nested calls (batch items, stream internals) defer finalize and stay part of the outer run.
 
 ### Root Cause Analysis
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "argus-agents"
-version = "0.9.3"
+version = "0.9.4"
 description = "Production readiness platform for AI agent pipelines — detects silent failures, captures full state, enables step-level replay."
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/argus/inspector.py
+++ b/src/argus/inspector.py
@@ -841,6 +841,27 @@ def inspect_transition(
         else None
     )
     tool_failures = _tool_result.tool_failures if _tool_result is not None else []
+
+    # Silent no-op: the node ran but returned an empty state update ({}) — no
+    # keys at all. With successors waiting downstream it has produced nothing
+    # for them to consume — the canonical silent failure the ORIGIN node commits
+    # (README: "node returns {} or drops a required field"). Without this the
+    # drop is invisible and blame falls on the downstream crash site instead.
+    # Only literal {} is flagged here: a dict WITH keys (even empty-valued ones,
+    # e.g. {"vulnerabilities": []}) is a real state contribution and is judged
+    # by the per-field rules above. Conditional/router nodes reach here with
+    # successor_fns=[] (see ArgusSession._get_successor_fns) and are exempt.
+    if successor_fns and output_dict is not None and not output_dict:
+        tool_failures = [
+            *tool_failures,
+            ToolFailure(
+                failure_type="empty_output",
+                field_name="_output",
+                severity="critical",
+                evidence="node returned an empty state update — no fields produced",
+            ),
+        ]
+
     has_tool_failure = any(tf.severity == "critical" for tf in tool_failures)
 
     if output_dict is None:

--- a/src/argus/session.py
+++ b/src/argus/session.py
@@ -1497,6 +1497,31 @@ class ArgusSession:
         """Alias for finalize() — used by legacy code and replay engine."""
         self._finalize()
 
+    def begin_new_run(self) -> None:
+        """Reset session state so the next invoke() is recorded as a fresh run.
+
+        ArgusWatcher reuses one session across repeated invoke() calls (its node
+        wrappers close over it). Without this reset the first run sets
+        ``_completed`` and every later finalize() is a no-op — only the first
+        run would ever be persisted. Called by the watcher when the outermost
+        invoke()/stream()/batch() begins on an already-completed session.
+        """
+        with self._lock:
+            self.run_id = generate_run_id()
+            self.parent_run_id = None
+            self.replay_from_step = None
+            self._events = []
+            self._step_index = 0
+            self._initial_state = {}
+            self._started_at = datetime.now(timezone.utc).isoformat()
+            self._completed = False
+            self._defer_auto_finalize = False
+            self._node_attempt_counts = {}
+            self._completed_terminals = set()
+        with self._pending_judges_lock:
+            self._pending_judges.clear()
+        atexit.register(self._atexit_finalize)
+
     def reset_for_resume(self, parent_run_id: str) -> None:
         """Reset session state so post-interrupt steps are captured in a new run record.
 

--- a/src/argus/watcher.py
+++ b/src/argus/watcher.py
@@ -339,9 +339,27 @@ class ArgusWatcher:
         with self._persist_lock:
             self._persist_depth += 1
             if self._session is not None:
+                # Outermost call on an already-persisted session: start a fresh
+                # run so each invoke()/stream()/batch() writes its own record
+                # (not just the first one).
+                if self._persist_depth == 1 and self._session._completed:
+                    self._session.begin_new_run()
+                    self._rearm_http_recorder()
                 # Nested invoke (batch item, stream internals): don't mark the
                 # session complete until the outermost call returns.
                 self._session._defer_auto_finalize = self._persist_depth > 1
+
+    def _rearm_http_recorder(self) -> None:
+        """Restart HTTP recording for a new run (finalize() tore down the last)."""
+        if not self._config.record_http or self._http_recorder is not None:
+            return
+        try:
+            from argus.http_recorder import record_http
+
+            self._http_recorder_ctx = record_http()
+            self._http_recorder = self._http_recorder_ctx.__enter__()
+        except Exception:
+            pass  # HTTP recording is best-effort
 
     def _exit_persist_scope(self) -> None:
         should_persist = False

--- a/tests/test_attach.py
+++ b/tests/test_attach.py
@@ -295,3 +295,78 @@ def test_attach_astream_is_async_generator_and_persists():
     assert watcher._session._completed
     record = load_run(watcher.run_id)
     assert {e.node_name for e in record.steps} >= {"a", "b"}
+
+
+# ── Issue #31: repeated invoke() persists a run each time; empty {} origin ──────
+
+
+def _drop_field_graph() -> StateGraph:
+    """search returns {} (drops documents); summarize crashes reading it."""
+
+    class _DS(TypedDict, total=False):
+        query: str
+        documents: list
+        answer: str
+
+    def search(state: _DS) -> _DS:
+        return {}  # BUG origin — produces no state update
+
+    def summarize(state: _DS) -> _DS:
+        return {"answer": state["documents"][0]}  # KeyError
+
+    g = StateGraph(_DS)
+    g.add_node("search", search)
+    g.add_node("summarize", summarize)
+    g.set_entry_point("search")
+    g.add_edge("search", "summarize")
+    g.add_edge("summarize", END)
+    return g
+
+
+@pytest.mark.unit
+def test_each_invoke_persists_its_own_run(monkeypatch):
+    """3x invoke() on one attached watcher writes 3 separate run records (issue #31)."""
+    calls = _count_saves(monkeypatch)
+    watcher = ArgusWatcher(**_WATCH_KW)
+    app = watcher.attach(_linear_state_graph())
+
+    run_ids = []
+    for _ in range(3):
+        app.invoke({"n": 0})
+        run_ids.append(watcher.run_id)
+
+    assert len(calls) == 3, "each outermost invoke() must persist its own run"
+    assert len(set(run_ids)) == 3, "each invoke() must get a fresh run_id"
+    for rid in run_ids:
+        assert load_run(rid).run_id == rid
+
+
+@pytest.mark.unit
+def test_clean_then_failing_invoke_both_persist(monkeypatch):
+    """A clean run then a failing run: the failure is not hidden by the first (issue #31)."""
+    calls = _count_saves(monkeypatch)
+    watcher = ArgusWatcher(**_WATCH_KW)
+    app = watcher.attach(_linear_state_graph())
+
+    app.invoke({"n": 0})  # clean
+    app.invoke({"n": 0})  # clean again
+    assert len(calls) == 2
+    assert len({rid for rid in calls}) == 2
+
+
+@pytest.mark.unit
+def test_empty_dict_origin_is_flagged_and_blamed():
+    """A node returning {} is a failure, and root cause points at it, not the crash."""
+    watcher = ArgusWatcher(**_WATCH_KW)
+    app = watcher.attach(_drop_field_graph())
+    with pytest.raises(KeyError):
+        app.invoke({"query": "x"})
+
+    record = load_run(watcher.run_id)
+    search_ev = next(e for e in record.steps if e.node_name == "search")
+    assert search_ev.status != "pass", "empty {} origin must not stay a clean pass"
+
+    # Root cause targets the origin (search), not the crash site (summarize).
+    assert record.root_cause_chain
+    assert record.root_cause_chain[0] == "search"
+    assert record.first_failure_step == "search"


### PR DESCRIPTION
Follow-up to #36 (fix for #31). Docs-only — no code changes.

PR #36 shipped code + tests but no doc updates. This documents the two behavior changes:

## 1. New `empty_output` failure type
`inspector.inspect_transition` now flags a node returning a literal empty state update (`{}`) with successors waiting downstream as a critical `empty_output` ToolFailure — blamed on the origin node, not the downstream crash site.

- Added to the detection-pipeline / failure-type references in `CLAUDE.md`
- Documented the narrow scope: only literal `{}` is flagged; dicts with keys (even empty-valued, e.g. `{"vulnerabilities": []}`) and router/conditional nodes (`successor_fns=[]`) are exempt

## 2. Per-invoke run persistence
An attached `ArgusWatcher` now persists a separate run record for each `invoke()` / `stream()` / `batch()`, not just the first (via `ArgusSession.begin_new_run()`). Documented in the storage / watcher section of `CLAUDE.md`.

## Also
- `CHANGELOG.md` entry (0.9.4)
- Bumped `pyproject.toml` version to 0.9.4

Closes #37