### PR TITLE
fix(show): nonzero exit on unresolvable run ids + clean ambiguous-prefix errors

### DIFF
--- a/src/argus/cli/main.py
+++ b/src/argus/cli/main.py
@@ -281,12 +281,15 @@ def cmd_show(
         if run_id == "run" and ctx.args:
             target_id = ctx.args[0]
         if target_id is None:
-            _console.print("[red]Error:[/red] No runs found.", err=True)
+            _console.print("[red]Error:[/red] No runs found.")
             raise typer.Exit(1)
         try:
             print(load_run_text(target_id))
         except FileNotFoundError as e:
-            _console.print(f"[red]Error:[/red] {e}", err=True)
+            _console.print(f"[red]Error:[/red] {e}")
+            raise typer.Exit(1)
+        except ValueError as e:
+            _console.print(f"[red]Error:[/red] {e}")
             raise typer.Exit(1)
         return
     if run_id is None or run_id == "last":
@@ -295,11 +298,32 @@ def cmd_show(
         # Backward compat: 'argus show run <id>' still works
         actual_id = ctx.args[0] if ctx.args else None
         if actual_id:
-            show_run(actual_id)
+            _show_run_strict(actual_id)
         else:
             show_last()
     else:
-        show_run(run_id)
+        _show_run_strict(run_id)
+
+
+def _show_run_strict(run_id: str) -> None:
+    """Render a specific run, exiting nonzero when the id can't be resolved.
+
+    ``show_run()`` prints errors and returns so the TUI stays friendly, but a
+    caller scripting ``argus show <id>`` then can't tell success from failure —
+    and an ambiguous prefix escaped as a raw traceback. Resolve first; on any
+    resolution failure print the reason and exit 1.
+    """
+    from argus.storage import load_run
+
+    try:
+        load_run(run_id)
+    except FileNotFoundError as e:
+        _console.print(f"[red]Error:[/red] {e}")
+        raise typer.Exit(1)
+    except ValueError as e:
+        _console.print(f"[red]Error:[/red] {e}")
+        raise typer.Exit(1)
+    show_run(run_id)
 
 
 @app.command("check")

--- a/tests/test_cmd_show_errors.py
+++ b/tests/test_cmd_show_errors.py
@@ -1,0 +1,88 @@
+"""``argus show <id>`` must fail loudly when the id can't be resolved.
+
+Companion to the #33 family: positional ids now resolve correctly, but the
+error paths still exited 0 (unknown id) or dumped a raw traceback (ambiguous
+prefix) — either way a script can't tell success from failure.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from conftest import make_event, make_run_record
+from typer.testing import CliRunner
+
+from argus.cli.main import app
+from argus.storage import save_run
+
+
+def _now(offset_s: float = 0.0) -> str:
+    return (datetime.now(timezone.utc) + timedelta(seconds=offset_s)).isoformat()
+
+
+def _save(run_id: str, offset_s: float = 0.0):
+    record = make_run_record(events=[make_event()], status="clean", run_id=run_id)
+    record.started_at = _now(offset_s)
+    save_run(record)
+    return record
+
+
+# ── happy paths keep working ─────────────────────────────────────────────────
+
+
+def test_show_known_full_id_renders_that_run():
+    _save("20260101-000001-aaaa1111")
+    newer = _save("20260101-000002-bbbb2222", offset_s=5)
+    result = CliRunner().invoke(app, ["show", "20260101-000001-aaaa1111"])
+    assert result.exit_code == 0, result.output
+    assert "20260101-000001-aaaa1111" in result.output
+    assert newer.run_id not in result.output.split("argus")[1]  # header shows requested run
+
+
+def test_show_unique_prefix_resolves():
+    _save("20260101-000003-cccc3333")
+    result = CliRunner().invoke(app, ["show", "20260101-000003"])
+    assert result.exit_code == 0, result.output
+    assert "20260101-000003-cccc3333" in result.output
+
+
+def test_show_run_form_resolves_requested_id_not_last():
+    _save("20260101-000004-dddd4444")
+    _save("20260101-000005-eeee5555", offset_s=5)
+    result = CliRunner().invoke(app, ["show", "run", "20260101-000004-dddd4444"])
+    assert result.exit_code == 0, result.output
+    assert "20260101-000004-dddd4444" in result.output
+
+
+# ── unresolvable ids exit nonzero with a clean message ──────────────────────
+
+
+def test_show_unknown_id_exits_one_with_error():
+    _save("20260101-000006-ffff6666")
+    result = CliRunner().invoke(app, ["show", "20990101-999999-zzzz9999"])
+    assert result.exit_code == 1, result.output
+    assert "Error" in result.output
+
+
+def test_show_ambiguous_prefix_exits_one_without_traceback():
+    _save("dupcase-aaa1")
+    _save("dupcase-aaa2")
+    result = CliRunner().invoke(app, ["show", "dupcase-aaa"])
+    assert result.exit_code == 1, result.output
+    assert "mbiguous" in result.output
+    assert "Traceback" not in result.output
+
+
+def test_show_json_unknown_id_exits_one():
+    result = CliRunner().invoke(app, ["show", "no-such-run", "--json"])
+    assert result.exit_code == 1
+    assert "Error" in result.output
+
+
+def test_show_json_ambiguous_prefix_exits_one_without_traceback():
+    _save("dupjson-aaa1")
+    _save("dupjson-aaa2")
+    result = CliRunner().invoke(app, ["show", "dupjson-aaa", "--json"])
+    assert result.exit_code == 1, result.output
+    assert "mbiguous" in result.output
+    assert "Traceback" not in result.output


### PR DESCRIPTION
## Problem

Three error paths in `argus show` misbehave for anyone scripting the CLI:

1. **Unknown id exits 0.** `argus show <bad-id>` prints `Error: …` then returns exit code 0 — success and failure are indistinguishable.
2. **Ambiguous prefix dumps a traceback.** A prefix matching multiple runs raises `ValueError` that only the `--json` family half-handles; the human path renders a full rich traceback panel.
3. **Latent crash on empty store.** `argus show last --json` with no runs calls `Console.print(..., err=True)` — not a real rich kwarg — so the intended friendly `No runs found.` message becomes a `TypeError` traceback.

(`argus check` / `argus fix` already exit 1 correctly on bad ids — this brings `show` in line.)

## Fix

- New `_show_run_strict()` helper resolves the id via `load_run()` first; on `FileNotFoundError`/`ValueError` prints one clean error line and exits 1. Used by both `show <id>` and the back-compat `show run <id>` form.
- `--json` path additionally catches `ValueError`.
- Dropped the invalid `err=True` kwargs (3 sites).

## Tests

`tests/test_cmd_show_errors.py` — 7 cases: full id / unique prefix / back-compat `run <id>` happy paths render the *requested* run (not newest); unknown id → exit 1; ambiguous prefix → exit 1 with message and no `Traceback` in output; both json error paths covered. All red before the fix, green after. Full suite: no regressions (only the two pre-existing `test_e2e_langgraph.py::TestCLI` env failures remain, which shell out to bare `python3 -m argus.cli.main` and fail identically on clean `dev` without an installed argus).

## Notes

- Verified empirically that #33's core claim (positional id ignored) does **not** reproduce on PyPI 0.10.1 nor current `dev` — all show forms resolve correctly. This PR hardens the adjacent error paths that issue surfaced; happy to close #33 alongside if maintainers confirm.