### PR TITLE
fix(key): nonzero exit on failed key set/use

### DIFF
--- a/src/argus/cli/cmd_key.py
+++ b/src/argus/cli/cmd_key.py
@@ -32,17 +32,20 @@ def _validate_provider(provider: str) -> bool:
     return True
 
 
-def key_set(value: str | None = None, provider: str = "openai") -> None:
-    """Save a provider key locally and make it the active provider."""
+def key_set(value: str | None = None, provider: str = "openai") -> bool:
+    """Save a provider key locally and make it the active provider.
+
+    Returns False when the operation failed (unknown provider, empty key).
+    """
     if not _validate_provider(provider):
-        return
+        return False
     if not value:
         import getpass
 
         value = getpass.getpass(f"{provider} API key (input hidden): ").strip()
     if not value:
         _console.print("  [red]No key entered.[/red]")
-        return
+        return False
     user_config.set_key(provider, value)
     user_config.set_provider(provider)
     _console.print(
@@ -57,21 +60,26 @@ def key_set(value: str | None = None, provider: str = "openai") -> None:
         "  Switch providers anytime with [bold]argus key use <provider>[/bold].\n"
         "  Check status with [bold]argus doctor[/bold].[/dim]"
     )
+    return True
 
 
-def key_use(provider: str) -> None:
-    """Switch the active provider (must already have a key)."""
+def key_use(provider: str) -> bool:
+    """Switch the active provider (must already have a key).
+
+    Returns False when the switch failed (unknown provider, no key saved).
+    """
     if not _validate_provider(provider):
-        return
+        return False
     if not user_config.resolve_key(provider):
         _console.print(
             f"  [yellow]No {provider} key set.[/yellow] Run "
             f"[bold]argus key set --provider {provider}[/bold] or export "
             f"{_ENV_HINT[provider]}."
         )
-        return
+        return False
     user_config.set_provider(provider)
     _console.print(f"  [green]Active provider set to[/green] {provider}")
+    return True
 
 
 def key_show() -> None:

--- a/src/argus/cli/main.py
+++ b/src/argus/cli/main.py
@@ -58,7 +58,8 @@ def cmd_key_set(
     ),
 ) -> None:
     """Save an LLM API key locally and activate that provider."""
-    key_set(value, provider)
+    if not key_set(value, provider):
+        raise typer.Exit(1)
 
 
 @key_app.command("use")
@@ -66,7 +67,8 @@ def cmd_key_use(
     provider: str = typer.Argument(help="Provider to activate: openai | anthropic | google."),
 ) -> None:
     """Switch the active LLM provider (must already have a key)."""
-    key_use(provider)
+    if not key_use(provider):
+        raise typer.Exit(1)
 
 
 @key_app.command("show")

--- a/tests/test_cmd_key_errors.py
+++ b/tests/test_cmd_key_errors.py
@@ -1,0 +1,50 @@
+"""``argus key set/use`` must exit nonzero when the operation fails.
+
+Both commands printed a friendly error ("Unknown provider", "No <p> key
+set") and then exited 0, so scripts gating on the exit code silently
+treated failed switches as success.
+"""
+
+from __future__ import annotations
+
+import pytest
+from typer.testing import CliRunner
+
+from argus.cli.main import app
+
+
+@pytest.mark.unit
+def test_key_use_unknown_provider_exits_one():
+    result = CliRunner().invoke(app, ["key", "use", "bogus"])
+    assert result.exit_code == 1, result.output
+    assert "Unknown provider" in result.output
+
+
+@pytest.mark.unit
+def test_key_set_unknown_provider_exits_one():
+    result = CliRunner().invoke(app, ["key", "set", "sk-test", "--provider", "bogus"])
+    assert result.exit_code == 1, result.output
+    assert "Unknown provider" in result.output
+
+
+@pytest.mark.unit
+def test_key_use_without_saved_key_exits_one(monkeypatch):
+    import argus.cli.cmd_key as cmd_key
+
+    monkeypatch.setattr(cmd_key.user_config, "resolve_key", lambda p: None)
+    result = CliRunner().invoke(app, ["key", "use", "anthropic"])
+    assert result.exit_code == 1, result.output
+    assert "No anthropic key set" in result.output
+
+
+@pytest.mark.unit
+def test_key_use_with_saved_key_exits_zero_and_activates(monkeypatch):
+    import argus.cli.cmd_key as cmd_key
+
+    monkeypatch.setattr(cmd_key.user_config, "resolve_key", lambda p: "sk-test-1234")
+    activated = []
+    monkeypatch.setattr(cmd_key.user_config, "set_provider", lambda p: activated.append(p))
+    result = CliRunner().invoke(app, ["key", "use", "anthropic"])
+    assert result.exit_code == 0, result.output
+    assert "Active provider set to" in result.output
+    assert activated == ["anthropic"]


### PR DESCRIPTION
## Problem

`argus key use <unknown>` prints `Unknown provider '…'` and **exits 0**. Same for:

- `key use <provider>` when that provider has no saved key,
- `key set --provider <unknown>`.

Anything scripting BYOK setup gates on exit codes and currently reads failed operations as success.

## Fix

- `key_set()` / `key_use()` return `bool` (False on every failure branch — unchanged messages/output otherwise).
- Typer wrappers raise `typer.Exit(1)` on False.
- No behavior change on success paths.

## Tests

`tests/test_cmd_key_errors.py`: unknown provider (use + set) → exit 1; unsaved-key switch → exit 1; saved-key switch → exit 0 and activates exactly the requested provider (`user_config` calls monkeypatched — no writes to real `~/.argus/config.json`). Full suite: only the two pre-existing env-dependent `TestCLI` e2e failures remain (fail identically on clean `dev`).

Companion to #39 — same error-path-exit-code disease, different command family.