### PR TITLE
Merge dev → master: show positional-id routing fix + #39/#40

### DIFF
--- a/src/argus/cli/main.py
+++ b/src/argus/cli/main.py
@@ -283,12 +283,15 @@ def cmd_show(
         if run_id == "run" and ctx.args:
             target_id = ctx.args[0]
         if target_id is None:
-            _console.print("[red]Error:[/red] No runs found.", err=True)
+            _console.print("[red]Error:[/red] No runs found.")
             raise typer.Exit(1)
         try:
             print(load_run_text(target_id))
         except FileNotFoundError as e:
-            _console.print(f"[red]Error:[/red] {e}", err=True)
+            _console.print(f"[red]Error:[/red] {e}")
+            raise typer.Exit(1)
+        except ValueError as e:
+            _console.print(f"[red]Error:[/red] {e}")
             raise typer.Exit(1)
         return
     if run_id is None or run_id == "last":
@@ -297,11 +300,32 @@ def cmd_show(
         # Backward compat: 'argus show run <id>' still works
         actual_id = ctx.args[0] if ctx.args else None
         if actual_id:
-            show_run(actual_id)
+            _show_run_strict(actual_id)
         else:
             show_last()
     else:
-        show_run(run_id)
+        _show_run_strict(run_id)
+
+
+def _show_run_strict(run_id: str) -> None:
+    """Render a specific run, exiting nonzero when the id can't be resolved.
+
+    ``show_run()`` prints errors and returns so the TUI stays friendly, but a
+    caller scripting ``argus show <id>`` then can't tell success from failure —
+    and an ambiguous prefix escaped as a raw traceback. Resolve first; on any
+    resolution failure print the reason and exit 1.
+    """
+    from argus.storage import load_run
+
+    try:
+        load_run(run_id)
+    except FileNotFoundError as e:
+        _console.print(f"[red]Error:[/red] {e}")
+        raise typer.Exit(1)
+    except ValueError as e:
+        _console.print(f"[red]Error:[/red] {e}")
+        raise typer.Exit(1)
+    show_run(run_id)
 
 
 @app.command("check")

--- a/src/argus/cli/main.py
+++ b/src/argus/cli/main.py
@@ -276,12 +276,18 @@ def cmd_show(
     ] = False,
 ) -> None:
     """Show run details. Use 'argus show last' or 'argus show <run-id>'."""
+    # allow_interspersed_args means Click may leave the positional id in
+    # ctx.args instead of binding run_id — normalize both into one token list
+    # so 'show <id>' actually resolves the id (not just the newest run).
+    tokens = ([run_id] if run_id else []) + list(ctx.args)
+    if tokens and tokens[0] == "run":  # back-compat: 'argus show run <id>'
+        tokens = tokens[1:]
+    selector = tokens[0] if tokens else None  # None or 'last' -> newest run
+
     if json:
         from argus.storage import last_run_id
 
-        target_id = run_id if (run_id and run_id not in ("last", "run")) else last_run_id()
-        if run_id == "run" and ctx.args:
-            target_id = ctx.args[0]
+        target_id = selector if (selector and selector != "last") else last_run_id()
         if target_id is None:
             _console.print("[red]Error:[/red] No runs found.")
             raise typer.Exit(1)
@@ -294,17 +300,10 @@ def cmd_show(
             _console.print(f"[red]Error:[/red] {e}")
             raise typer.Exit(1)
         return
-    if run_id is None or run_id == "last":
+    if selector is None or selector == "last":
         show_last()
-    elif run_id == "run":
-        # Backward compat: 'argus show run <id>' still works
-        actual_id = ctx.args[0] if ctx.args else None
-        if actual_id:
-            _show_run_strict(actual_id)
-        else:
-            show_last()
     else:
-        _show_run_strict(run_id)
+        _show_run_strict(selector)
 
 
 def _show_run_strict(run_id: str) -> None:

--- a/tests/test_cmd_show_errors.py
+++ b/tests/test_cmd_show_errors.py
@@ -1,0 +1,88 @@
+"""``argus show <id>`` must fail loudly when the id can't be resolved.
+
+Companion to the #33 family: positional ids now resolve correctly, but the
+error paths still exited 0 (unknown id) or dumped a raw traceback (ambiguous
+prefix) — either way a script can't tell success from failure.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from conftest import make_event, make_run_record
+from typer.testing import CliRunner
+
+from argus.cli.main import app
+from argus.storage import save_run
+
+
+def _now(offset_s: float = 0.0) -> str:
+    return (datetime.now(timezone.utc) + timedelta(seconds=offset_s)).isoformat()
+
+
+def _save(run_id: str, offset_s: float = 0.0):
+    record = make_run_record(events=[make_event()], status="clean", run_id=run_id)
+    record.started_at = _now(offset_s)
+    save_run(record)
+    return record
+
+
+# ── happy paths keep working ─────────────────────────────────────────────────
+
+
+def test_show_known_full_id_renders_that_run():
+    _save("20260101-000001-aaaa1111")
+    newer = _save("20260101-000002-bbbb2222", offset_s=5)
+    result = CliRunner().invoke(app, ["show", "20260101-000001-aaaa1111"])
+    assert result.exit_code == 0, result.output
+    assert "20260101-000001-aaaa1111" in result.output
+    assert newer.run_id not in result.output.split("argus")[1]  # header shows requested run
+
+
+def test_show_unique_prefix_resolves():
+    _save("20260101-000003-cccc3333")
+    result = CliRunner().invoke(app, ["show", "20260101-000003"])
+    assert result.exit_code == 0, result.output
+    assert "20260101-000003-cccc3333" in result.output
+
+
+def test_show_run_form_resolves_requested_id_not_last():
+    _save("20260101-000004-dddd4444")
+    _save("20260101-000005-eeee5555", offset_s=5)
+    result = CliRunner().invoke(app, ["show", "run", "20260101-000004-dddd4444"])
+    assert result.exit_code == 0, result.output
+    assert "20260101-000004-dddd4444" in result.output
+
+
+# ── unresolvable ids exit nonzero with a clean message ──────────────────────
+
+
+def test_show_unknown_id_exits_one_with_error():
+    _save("20260101-000006-ffff6666")
+    result = CliRunner().invoke(app, ["show", "20990101-999999-zzzz9999"])
+    assert result.exit_code == 1, result.output
+    assert "Error" in result.output
+
+
+def test_show_ambiguous_prefix_exits_one_without_traceback():
+    _save("dupcase-aaa1")
+    _save("dupcase-aaa2")
+    result = CliRunner().invoke(app, ["show", "dupcase-aaa"])
+    assert result.exit_code == 1, result.output
+    assert "mbiguous" in result.output
+    assert "Traceback" not in result.output
+
+
+def test_show_json_unknown_id_exits_one():
+    result = CliRunner().invoke(app, ["show", "no-such-run", "--json"])
+    assert result.exit_code == 1
+    assert "Error" in result.output
+
+
+def test_show_json_ambiguous_prefix_exits_one_without_traceback():
+    _save("dupjson-aaa1")
+    _save("dupjson-aaa2")
+    result = CliRunner().invoke(app, ["show", "dupjson-aaa", "--json"])
+    assert result.exit_code == 1, result.output
+    assert "mbiguous" in result.output
+    assert "Traceback" not in result.output


### PR DESCRIPTION
Brings dev up to master:
- fix(show): bind positional run-id from ctx.args so `show <id>` resolves the id (root-cause fix for #33; makes #39's `_show_run_strict` reachable — its 7 tests now pass)
- #39 (show exit codes) and #40 (key exit codes) already on dev

Runs full CI before merge.