### PR TITLE
feat: add semantic signatures for token-limit, self-reference, and lazy-truncation phrases

### DIFF
--- a/src/argus/data/signatures.json
+++ b/src/argus/data/signatures.json
@@ -722,6 +722,126 @@
       }
     },
     {
+      "id": "SP-019",
+      "category": "suspicious_phrases",
+      "pattern": "reached my token limit",
+      "match_strategy": "contains_ci",
+      "severity": "warning",
+      "description": "Model reports hitting its token limit — output is truncated",
+      "source": "builtin",
+      "metadata": {
+        "confidence": null,
+        "frequency": null,
+        "approval_status": "approved",
+        "framework_specific": null
+      }
+    },
+    {
+      "id": "SP-020",
+      "category": "suspicious_phrases",
+      "pattern": "due to length constraints",
+      "match_strategy": "contains_ci",
+      "severity": "warning",
+      "description": "Model truncated its output citing length constraints",
+      "source": "builtin",
+      "metadata": {
+        "confidence": null,
+        "frequency": null,
+        "approval_status": "approved",
+        "framework_specific": null
+      }
+    },
+    {
+      "id": "SP-021",
+      "category": "suspicious_phrases",
+      "pattern": "response was truncated",
+      "match_strategy": "contains_ci",
+      "severity": "warning",
+      "description": "Model states its own response was truncated — incomplete output",
+      "source": "builtin",
+      "metadata": {
+        "confidence": null,
+        "frequency": null,
+        "approval_status": "approved",
+        "framework_specific": null
+      }
+    },
+    {
+      "id": "SP-022",
+      "category": "suspicious_phrases",
+      "pattern": "as mentioned above",
+      "match_strategy": "contains_ci",
+      "severity": "warning",
+      "description": "Back-reference to absent prior context in a single-turn node — model assumes conversation history that isn't present",
+      "source": "builtin",
+      "metadata": {
+        "confidence": null,
+        "frequency": null,
+        "approval_status": "approved",
+        "framework_specific": null
+      }
+    },
+    {
+      "id": "SP-023",
+      "category": "suspicious_phrases",
+      "pattern": "as i said earlier",
+      "match_strategy": "contains_ci",
+      "severity": "warning",
+      "description": "Self-referential back-reference — model assumes an earlier turn that doesn't exist",
+      "source": "builtin",
+      "metadata": {
+        "confidence": null,
+        "frequency": null,
+        "approval_status": "approved",
+        "framework_specific": null
+      }
+    },
+    {
+      "id": "SP-024",
+      "category": "suspicious_phrases",
+      "pattern": "as previously mentioned",
+      "match_strategy": "contains_ci",
+      "severity": "warning",
+      "description": "Back-reference to absent prior context — model assumes information it was never given",
+      "source": "builtin",
+      "metadata": {
+        "confidence": null,
+        "frequency": null,
+        "approval_status": "approved",
+        "framework_specific": null
+      }
+    },
+    {
+      "id": "SP-025",
+      "category": "suspicious_phrases",
+      "pattern": "\\band many more\\.?\\s*$",
+      "match_strategy": "regex",
+      "severity": "warning",
+      "description": "Output ends with 'and many more' — enumeration abandoned mid-list",
+      "source": "builtin",
+      "metadata": {
+        "confidence": null,
+        "frequency": null,
+        "approval_status": "approved",
+        "framework_specific": null
+      }
+    },
+    {
+      "id": "SP-026",
+      "category": "suspicious_phrases",
+      "pattern": "\\band so on\\.?\\s*$",
+      "match_strategy": "regex",
+      "severity": "warning",
+      "description": "Output ends with 'and so on' — enumeration abandoned mid-list",
+      "source": "builtin",
+      "metadata": {
+        "confidence": null,
+        "frequency": null,
+        "approval_status": "approved",
+        "framework_specific": null
+      }
+    },
+    {
       "id": "MP-001",
       "category": "malformed_payload",
       "pattern": "^\\{\\s*\\}$",

--- a/tests/test_registry_unit.py
+++ b/tests/test_registry_unit.py
@@ -270,3 +270,50 @@ class TestNaturalUncertaintySignatures:
         matches = scan_value("N/A", registry)
         new_ids = {m.sig_id for m in matches if m.sig_id in {"SP-014", "SP-015", "SP-016"}}
         assert not new_ids
+
+
+@pytest.mark.unit
+class TestDegradationPhraseSignatures:
+    """SP-019..SP-026 — token-limit, self-reference, and lazy-truncation phrases."""
+
+    @pytest.mark.parametrize(
+        ("text", "expected"),
+        [
+            ("I have reached my token limit, so I'll stop here.", "SP-019"),
+            ("The output was cut short due to length constraints.", "SP-020"),
+            ("Note: the response was truncated by the provider.", "SP-021"),
+            ("As mentioned above, the totals reconcile.", "SP-022"),
+            ("As I said earlier, the retry failed.", "SP-023"),
+            ("The config, as previously mentioned, is invalid.", "SP-024"),
+            ("Affected files: a.py, b.py, c.py, and many more", "SP-025"),
+            ("Pipeline stages: init, build, deploy, and so on.", "SP-026"),
+        ],
+    )
+    def test_phrase_hits(self, registry, text, expected):
+        ids = {m.sig_id for m in scan_value(text, registry)}
+        assert expected in ids
+
+    def test_all_are_warning_severity(self, registry):
+        new = [s for s in registry if s["id"] in {f"SP-{n:03d}" for n in range(19, 27)}]
+        assert len(new) == 8
+        assert all(s["severity"] == "warning" for s in new)
+        assert all(s["category"] == "suspicious_phrases" for s in new)
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "Tesla stock rose 5.3% today on strong Q3 earnings, beating expectations.",
+            "We iterate and so on the process converges only after several more runs.",
+            "The dataset has many more rows than the sample shown in table 2.",
+            "The token limit for this model is 128k; we stayed well under it.",
+        ],
+    )
+    def test_no_false_positive_on_normal_prose(self, registry, text):
+        ids = {m.sig_id for m in scan_value(text, registry)}
+        assert not (ids & {f"SP-{n:03d}" for n in range(19, 27)})
+
+    def test_lazy_truncation_only_matches_at_end(self, registry):
+        """SP-025/026 are end-anchored — the phrase mid-sentence must not fire."""
+        mid = "The list goes on and so on until the loop exits and then we return."
+        ids = {m.sig_id for m in scan_value(mid, registry)}
+        assert "SP-026" not in ids


### PR DESCRIPTION
Closes #23.

## What

Adds 8 signatures (`SP-019`–`SP-026`) to `src/argus/data/signatures.json`, all in the existing `suspicious_phrases` category at `warning` severity, so `inspector.py`'s `_CATEGORY_TO_FAILURE` map is unchanged (they resolve to `semantic_degradation`).

| ID | Strategy | Pattern | Catches |
|----|----------|---------|---------|
| SP-019 | `contains_ci` | `reached my token limit` | model admits truncation |
| SP-020 | `contains_ci` | `due to length constraints` | model admits truncation |
| SP-021 | `contains_ci` | `response was truncated` | model admits truncation |
| SP-022 | `contains_ci` | `as mentioned above` | back-reference to absent prior context in a single-turn node |
| SP-023 | `contains_ci` | `as i said earlier` | back-reference to absent prior context |
| SP-024 | `contains_ci` | `as previously mentioned` | back-reference to absent prior context |
| SP-025 | `regex` | `\band many more\.?\s*$` | enumeration abandoned at end of output |
| SP-026 | `regex` | `\band so on\.?\s*$` | enumeration abandoned at end of output |

The two lazy-truncation regexes are end-anchored (`\s*$`) so the same phrase mid-sentence in normal prose does not fire.

## Scope

The issue lists five pattern groups; this PR takes three. I deliberately left out:

- **Markdown artifacts in structured output** (`###`, `**bold**`) — the registry scans every string field with no knowledge of which fields expect plain text, and many agents legitimately emit Markdown, so a global signature would be noisy.
- **Language mixing** (English prompt → partial CJK response) — same problem: the registry has no locale context, so a CJK-run signature would false-positive on every non-English pipeline.

Both are better handled by the LLM semantic judge, which has field and prompt context.

## Tests

New `TestDegradationPhraseSignatures` in `tests/test_registry_unit.py`:
- parametrised positive match for each of the 8 signatures
- false-positive guards on normal prose ("...has many more rows than...", "...and so on the process converges...", "the token limit for this model is 128k")
- end-anchor check for SP-025/026

`ruff check .` clean; `pytest tests/test_registry_unit.py tests/test_signatures_false_positives.py tests/test_signature_stats.py` green (66 passed, 2 pre-existing xfail).

## Label

`enhancement`