### PR TITLE
feat: detect truncation and stale-context phrases in LLM output

### DIFF
--- a/src/argus/data/signatures.json
+++ b/src/argus/data/signatures.json
@@ -772,7 +772,7 @@
       "pattern": "as mentioned above",
       "match_strategy": "contains_ci",
       "severity": "warning",
-      "description": "Back-reference to absent prior context in a single-turn node — model assumes conversation history that isn't present",
+      "description": "Back-reference to earlier content — the referenced context may not exist in what this node was given",
       "source": "builtin",
       "metadata": {
         "confidence": null,
@@ -787,7 +787,7 @@
       "pattern": "as i said earlier",
       "match_strategy": "contains_ci",
       "severity": "warning",
-      "description": "Self-referential back-reference — model assumes an earlier turn that doesn't exist",
+      "description": "Self-referential back-reference to a previous turn — may assume conversation history the node never received",
       "source": "builtin",
       "metadata": {
         "confidence": null,
@@ -802,7 +802,7 @@
       "pattern": "as previously mentioned",
       "match_strategy": "contains_ci",
       "severity": "warning",
-      "description": "Back-reference to absent prior context — model assumes information it was never given",
+      "description": "Back-reference to previously supplied information — may assume context the node was never given",
       "source": "builtin",
       "metadata": {
         "confidence": null,
@@ -814,7 +814,7 @@
     {
       "id": "SP-025",
       "category": "suspicious_phrases",
-      "pattern": "\\band many more\\.?\\s*$",
+      "pattern": "\\band many more[.…]*\\s*$",
       "match_strategy": "regex",
       "severity": "warning",
       "description": "Output ends with 'and many more' — enumeration abandoned mid-list",
@@ -829,7 +829,7 @@
     {
       "id": "SP-026",
       "category": "suspicious_phrases",
-      "pattern": "\\band so on\\.?\\s*$",
+      "pattern": "\\band so on[.…]*\\s*$",
       "match_strategy": "regex",
       "severity": "warning",
       "description": "Output ends with 'and so on' — enumeration abandoned mid-list",

--- a/src/argus/data/signatures.json
+++ b/src/argus/data/signatures.json
@@ -722,6 +722,126 @@
       }
     },
     {
+      "id": "SP-019",
+      "category": "suspicious_phrases",
+      "pattern": "reached my token limit",
+      "match_strategy": "contains_ci",
+      "severity": "warning",
+      "description": "Model reports hitting its token limit — output is truncated",
+      "source": "builtin",
+      "metadata": {
+        "confidence": null,
+        "frequency": null,
+        "approval_status": "approved",
+        "framework_specific": null
+      }
+    },
+    {
+      "id": "SP-020",
+      "category": "suspicious_phrases",
+      "pattern": "due to length constraints",
+      "match_strategy": "contains_ci",
+      "severity": "warning",
+      "description": "Model truncated its output citing length constraints",
+      "source": "builtin",
+      "metadata": {
+        "confidence": null,
+        "frequency": null,
+        "approval_status": "approved",
+        "framework_specific": null
+      }
+    },
+    {
+      "id": "SP-021",
+      "category": "suspicious_phrases",
+      "pattern": "response was truncated",
+      "match_strategy": "contains_ci",
+      "severity": "warning",
+      "description": "Model states its own response was truncated — incomplete output",
+      "source": "builtin",
+      "metadata": {
+        "confidence": null,
+        "frequency": null,
+        "approval_status": "approved",
+        "framework_specific": null
+      }
+    },
+    {
+      "id": "SP-022",
+      "category": "suspicious_phrases",
+      "pattern": "as mentioned above",
+      "match_strategy": "contains_ci",
+      "severity": "warning",
+      "description": "Back-reference to absent prior context in a single-turn node — model assumes conversation history that isn't present",
+      "source": "builtin",
+      "metadata": {
+        "confidence": null,
+        "frequency": null,
+        "approval_status": "approved",
+        "framework_specific": null
+      }
+    },
+    {
+      "id": "SP-023",
+      "category": "suspicious_phrases",
+      "pattern": "as i said earlier",
+      "match_strategy": "contains_ci",
+      "severity": "warning",
+      "description": "Self-referential back-reference — model assumes an earlier turn that doesn't exist",
+      "source": "builtin",
+      "metadata": {
+        "confidence": null,
+        "frequency": null,
+        "approval_status": "approved",
+        "framework_specific": null
+      }
+    },
+    {
+      "id": "SP-024",
+      "category": "suspicious_phrases",
+      "pattern": "as previously mentioned",
+      "match_strategy": "contains_ci",
+      "severity": "warning",
+      "description": "Back-reference to absent prior context — model assumes information it was never given",
+      "source": "builtin",
+      "metadata": {
+        "confidence": null,
+        "frequency": null,
+        "approval_status": "approved",
+        "framework_specific": null
+      }
+    },
+    {
+      "id": "SP-025",
+      "category": "suspicious_phrases",
+      "pattern": "\\band many more\\.?\\s*$",
+      "match_strategy": "regex",
+      "severity": "warning",
+      "description": "Output ends with 'and many more' — enumeration abandoned mid-list",
+      "source": "builtin",
+      "metadata": {
+        "confidence": null,
+        "frequency": null,
+        "approval_status": "approved",
+        "framework_specific": null
+      }
+    },
+    {
+      "id": "SP-026",
+      "category": "suspicious_phrases",
+      "pattern": "\\band so on\\.?\\s*$",
+      "match_strategy": "regex",
+      "severity": "warning",
+      "description": "Output ends with 'and so on' — enumeration abandoned mid-list",
+      "source": "builtin",
+      "metadata": {
+        "confidence": null,
+        "frequency": null,
+        "approval_status": "approved",
+        "framework_specific": null
+      }
+    },
+    {
       "id": "MP-001",
       "category": "malformed_payload",
       "pattern": "^\\{\\s*\\}$",

--- a/tests/test_registry_unit.py
+++ b/tests/test_registry_unit.py
@@ -317,3 +317,16 @@ class TestDegradationPhraseSignatures:
         mid = "The list goes on and so on until the loop exits and then we return."
         ids = {m.sig_id for m in scan_value(mid, registry)}
         assert "SP-026" not in ids
+
+    @pytest.mark.parametrize(
+        ("text", "expected"),
+        [
+            ("Affected files: a.py, b.py, c.py, and so on...", "SP-026"),
+            ("Stages: init, build, deploy, and many more...", "SP-025"),
+            ("Stages: init, build, deploy, and so on…", "SP-026"),
+        ],
+    )
+    def test_lazy_truncation_matches_ellipsis(self, registry, text, expected):
+        """SP-025/026 must catch the ellipsis-terminated form, not just a bare period."""
+        ids = {m.sig_id for m in scan_value(text, registry)}
+        assert expected in ids

--- a/tests/test_registry_unit.py
+++ b/tests/test_registry_unit.py
@@ -270,3 +270,50 @@ class TestNaturalUncertaintySignatures:
         matches = scan_value("N/A", registry)
         new_ids = {m.sig_id for m in matches if m.sig_id in {"SP-014", "SP-015", "SP-016"}}
         assert not new_ids
+
+
+@pytest.mark.unit
+class TestDegradationPhraseSignatures:
+    """SP-019..SP-026 — token-limit, self-reference, and lazy-truncation phrases."""
+
+    @pytest.mark.parametrize(
+        ("text", "expected"),
+        [
+            ("I have reached my token limit, so I'll stop here.", "SP-019"),
+            ("The output was cut short due to length constraints.", "SP-020"),
+            ("Note: the response was truncated by the provider.", "SP-021"),
+            ("As mentioned above, the totals reconcile.", "SP-022"),
+            ("As I said earlier, the retry failed.", "SP-023"),
+            ("The config, as previously mentioned, is invalid.", "SP-024"),
+            ("Affected files: a.py, b.py, c.py, and many more", "SP-025"),
+            ("Pipeline stages: init, build, deploy, and so on.", "SP-026"),
+        ],
+    )
+    def test_phrase_hits(self, registry, text, expected):
+        ids = {m.sig_id for m in scan_value(text, registry)}
+        assert expected in ids
+
+    def test_all_are_warning_severity(self, registry):
+        new = [s for s in registry if s["id"] in {f"SP-{n:03d}" for n in range(19, 27)}]
+        assert len(new) == 8
+        assert all(s["severity"] == "warning" for s in new)
+        assert all(s["category"] == "suspicious_phrases" for s in new)
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "Tesla stock rose 5.3% today on strong Q3 earnings, beating expectations.",
+            "We iterate and so on the process converges only after several more runs.",
+            "The dataset has many more rows than the sample shown in table 2.",
+            "The token limit for this model is 128k; we stayed well under it.",
+        ],
+    )
+    def test_no_false_positive_on_normal_prose(self, registry, text):
+        ids = {m.sig_id for m in scan_value(text, registry)}
+        assert not (ids & {f"SP-{n:03d}" for n in range(19, 27)})
+
+    def test_lazy_truncation_only_matches_at_end(self, registry):
+        """SP-025/026 are end-anchored — the phrase mid-sentence must not fire."""
+        mid = "The list goes on and so on until the loop exits and then we return."
+        ids = {m.sig_id for m in scan_value(mid, registry)}
+        assert "SP-026" not in ids


### PR DESCRIPTION
Closes #23.

Adds SP-019..026 to signatures.json (suspicious_phrases, warning severity):
- truncation admissions ("reached my token limit", "response was truncated")
- back-references to missing context ("as mentioned above")
- trailing "and so on" / "and many more" (end-anchored regex)

Tests in tests/test_registry_unit.py. Skipped the markdown-artifact and
language-mixing ideas from the issue — too false-positive-prone in a
context-free registry.