### PR TITLE
docs: correct stale signature-registry facts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,8 +93,9 @@ Detects placeholder/degraded LLM outputs using match strategies:
 - `exact_ci`, `contains_ci`, `prefix_ci`: string matching
 - `regex`: compiled pattern
 - `repetition`: n-gram repetition detection
+- `semantic_similarity`: embedding cosine match (6 bundled signatures use it)
 
-Categories: `placeholder_outputs`, `null_like_semantic`, `suspicious_phrases`, `corrupted_markers`, `repeated_filler_text`, `malformed_embedded_json` → mapped to `placeholder_detected` or `semantic_degradation` failure types.
+Categories: `placeholder_outputs`, `null_like_semantic`, `suspicious_phrases`, `corrupted_markers`, `repeated_filler`, `malformed_payload`, `empty_semantic_state`, `semantic_refusal` → mapped to `placeholder_detected`, `semantic_degradation`, or `structural_anomaly` failure types by `_CATEGORY_TO_FAILURE` in `inspector.py`.
 
 ### LLM Transport
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ Building adapters now would mean rewriting them every few versions. Once the cor
 
 ### Detection Signatures
 
-The semantic signature registry (`src/argus/data/signatures.json`) ships with 61 patterns across 6 categories. More real-world patterns are needed:
+The semantic signature registry (`src/argus/data/signatures.json`) ships with 72 patterns across 8 categories. More real-world patterns are needed:
 
 - **LLM refusal variants** — new refusal phrasings from Claude, Gemini, Llama, Mistral
 - **Hallucination markers** — confident-sounding but fabricated outputs


### PR DESCRIPTION
Found while reviewing #43. Both contributor-facing docs describe the signature registry incorrectly, which is exactly the wrong place to be wrong — these are the lines a new contributor reads before touching `signatures.json`.

### CONTRIBUTING.md

Said 61 patterns across 6 categories. Actual, counted from `src/argus/data/signatures.json` on master:

```
total 72   categories 8
  placeholder_outputs   13      suspicious_phrases    18
  corrupted_markers      9      null_like_semantic     8
  malformed_payload      7      empty_semantic_state   6
  semantic_refusal       6      repeated_filler        5
```

### CLAUDE.md

The category list was wrong three separate ways:

- `repeated_filler_text` and `malformed_embedded_json` aren't real category names — they're `repeated_filler` and `malformed_payload`. Anyone copying those into a new signature gets a category that `_CATEGORY_TO_FAILURE` doesn't know.
- `empty_semantic_state` and `semantic_refusal` were missing entirely (12 signatures between them).
- The mapping claim ("→ `placeholder_detected` or `semantic_degradation`") missed a third target: `empty_semantic_state` maps to `structural_anomaly`.

The list now matches `_CATEGORY_TO_FAILURE` in `inspector.py:192-201` exactly. Verified:

```
json cats == mapping keys: True
unmapped: set()  | mapping-only: set()
failure types used: ['placeholder_detected', 'semantic_degradation', 'structural_anomaly']
```

Also added `semantic_similarity` to the match-strategy list — `_dispatch` handles it and 6 bundled signatures use it, but it wasn't documented.

### Not fixed here

`models.py:398` carries the same stale strategy list as a comment (`# "exact_ci" | "contains_ci" | "prefix_ci" | "regex"` — missing `repetition` and `semantic_similarity`). Left alone to keep this docs-only; happy to fold it in if you'd rather have one PR.

Docs only, no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YYRgNW4XPJ72BH6uLSf6Xo