### PR TITLE
feat: detect enumeration abandoned with a trailing "etc."

### DIFF
--- a/src/argus/data/signatures.json
+++ b/src/argus/data/signatures.json
@@ -722,6 +722,21 @@
       }
     },
     {
+      "id": "SP-027",
+      "category": "suspicious_phrases",
+      "pattern": "(?<![/\\\\])\\b(etc|et cetera)[.\u2026]*\\s*$",
+      "match_strategy": "regex",
+      "severity": "warning",
+      "description": "Output ends with 'etc.' — enumeration abandoned mid-list",
+      "source": "builtin",
+      "metadata": {
+        "confidence": null,
+        "frequency": null,
+        "approval_status": "approved",
+        "framework_specific": null
+      }
+    },
+    {
       "id": "MP-001",
       "category": "malformed_payload",
       "pattern": "^\\{\\s*\\}$",

--- a/tests/test_registry_unit.py
+++ b/tests/test_registry_unit.py
@@ -270,3 +270,41 @@ class TestNaturalUncertaintySignatures:
         matches = scan_value("N/A", registry)
         new_ids = {m.sig_id for m in matches if m.sig_id in {"SP-014", "SP-015", "SP-016"}}
         assert not new_ids
+
+
+@pytest.mark.unit
+class TestEtcLazyTruncation:
+    """SP-027 — enumeration abandoned with a trailing 'etc.'."""
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "Pipeline stages: init, build, deploy, etc.",
+            "Fields: id, name, email, etc",
+            "Supported formats: json, yaml, toml, etc...",
+            "Items: a, b, c, et cetera.",
+            "Stages: init, build, ETC.",
+        ],
+    )
+    def test_trailing_etc_hits(self, registry, text):
+        ids = {m.sig_id for m in scan_value(text, registry)}
+        assert "SP-027" in ids
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "We use etc. for brevity in the list above.",
+            "The /etc/passwd file was modified during the run.",
+            "Config lives under /etc",
+            "The fetcher retried twice before giving up.",
+            "Sketch etcher tools are unrelated to this pipeline.",
+        ],
+    )
+    def test_no_false_positive(self, registry, text):
+        ids = {m.sig_id for m in scan_value(text, registry)}
+        assert "SP-027" not in ids
+
+    def test_severity_and_category(self, registry):
+        sig = next(s for s in registry if s["id"] == "SP-027")
+        assert sig["severity"] == "warning"
+        assert sig["category"] == "suspicious_phrases"


### PR DESCRIPTION
Picks up the one lazy-truncation phrase from #23 that #43 doesn't cover. #23 lists `"...and many more"`, `"etc."`, `"and so on"` together; #43 ships the first and third and skips `etc.` without comment.

### The signature

```
(?<![/\\])\b(etc|et cetera)[.…]*\s*$
```

End-anchored like SP-025/026, so `etc.` mid-sentence never fires — only an output that *stops* at it. Two guards beyond the plain anchor:

- **negative lookbehind for `/` and `\`** — otherwise `"Config lives under /etc"` matches, and `/etc` paths are everywhere in tool output
- **`\b`** — otherwise `fetcher` and `etcher` match

`et cetera` spelled out rides along in the same alternation. Trailing ellipsis is handled (`[.…]*`), including U+2026.

### Verified against the loaded registry

```
'Stages: init, build, deploy, etc.'      -> ['SP-027']
'The /etc/passwd file was modified'      -> []
```

Tests are in `TestEtcLazyTruncation`: 5 positives (uppercase, bare `etc`, trailing `...`, `et cetera`) and 5 FP guards (mid-sentence use, two `/etc` paths, `fetcher`, `etcher`).

Full suite: 687 passed, same 28 pre-existing failures as `master` on this machine (packaging/plugin tests that need `pip install -e`, unrelated). `ruff check` clean.

### One coordination note

I numbered this **SP-027** on the assumption #43 lands first and takes SP-019..026. If #43 is dropped or renumbered, say the word and I'll renumber this to SP-019 — the id is an opaque key, nothing keys off the sequence.

Both PRs append a test class to the end of `tests/test_registry_unit.py`, so whichever merges second may need a trivial conflict resolution there. No overlap in `signatures.json` — different hunks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YYRgNW4XPJ72BH6uLSf6Xo