### PR TITLE
fix: warning-severity semantic signals no longer fail a node on their own

### DIFF
--- a/src/argus/candidate_store.py
+++ b/src/argus/candidate_store.py
@@ -163,7 +163,11 @@ def approve_candidate(candidate_id: str) -> dict[str, Any] | None:
         "category": cand["proposed_category"],
         "pattern": cand["pattern"],
         "match_strategy": cand["match_strategy"],
-        "severity": cand["severity"],
+        # Approval promotes severity to critical: a candidate is a hedge
+        # (LLM-suggested, unconfirmed), but a developer explicitly approving
+        # it is a confirmed, recurring pattern — no longer ambiguous, so it
+        # should flag future runs on its own rather than sit as advisory-only.
+        "severity": "critical",
         "description": cand["description"],
         "source": "learned",
         "metadata": {
@@ -174,6 +178,7 @@ def approve_candidate(candidate_id: str) -> dict[str, Any] | None:
             "framework_specific": None,
             "original_pattern": cand.get("original_pattern"),
             "generalized": cand.get("generalized", False),
+            "suggested_severity": cand["severity"],
         },
     }
     custom["signatures"].append(new_sig)
@@ -234,7 +239,10 @@ def approve_candidate_shared(candidate_id: str) -> dict[str, Any] | None:
         "category": cand["proposed_category"],
         "pattern": cand["pattern"],
         "match_strategy": cand["match_strategy"],
-        "severity": cand["severity"],
+        # Same promotion as approve_candidate: an approved (and now
+        # community-shared) pattern is confirmed, not a hedge, so it should
+        # flag future runs on its own rather than sit as advisory-only.
+        "severity": "critical",
         "description": cand["description"],
         "source": "shared",
         "source_run_ids": cand.get("source_run_ids", []),
@@ -248,6 +256,7 @@ def approve_candidate_shared(candidate_id: str) -> dict[str, Any] | None:
             "framework_specific": None,
             "original_pattern": cand.get("original_pattern"),
             "generalized": cand.get("generalized", False),
+            "suggested_severity": cand["severity"],
         },
     }
 

--- a/src/argus/session.py
+++ b/src/argus/session.py
@@ -784,7 +784,14 @@ class ArgusSession:
                 self._check_latency_signals(duration_ms, inspection)
                 # Determine raw status from inspection
                 _has_failure = inspection.is_silent_failure or inspection.has_tool_failure
-                _has_signals = bool(inspection.semantic_signals)
+                # Only critical-severity semantic signals affect status — a
+                # "warning" signal (e.g. an ambiguous suspicious-phrase match)
+                # is recorded on the event for visibility but must not alone
+                # fail the node. Mirrors how ToolFailure already gates on
+                # severity == "critical" for has_tool_failure above.
+                _has_signals = any(
+                    s.severity == "critical" for s in inspection.semantic_signals
+                )
 
                 if _has_failure or _has_signals:
                     # Before blaming this node, check if it's operating on
@@ -1067,7 +1074,12 @@ class ArgusSession:
                 _has_failure = (
                     inspection.is_silent_failure or inspection.has_tool_failure
                 )
-                _has_signals = bool(inspection.semantic_signals)
+                # Same severity gate as the initial status determination —
+                # a leftover warning-severity signal shouldn't re-fail a
+                # node the disambiguation pass otherwise cleared.
+                _has_signals = any(
+                    s.severity == "critical" for s in inspection.semantic_signals
+                )
                 if not _has_failure and not _has_signals:
                     status = "pass"
                 elif _has_failure:

--- a/tests/test_db_flow.py
+++ b/tests/test_db_flow.py
@@ -178,8 +178,14 @@ def test_3_private_db_flags_next_run():
     step = run["steps"][0]
 
     assert step["node_name"] == "summarize"
-    assert step["status"] == "semantic_fail", (
-        f"Node should be semantic_fail, got {step['status']!r}. "
+    # Approval promotes severity to critical (a confirmed pattern, not a
+    # hedge — see candidate_store.approve_candidate). Whether that lands as
+    # "fail" or "semantic_fail" depends on a separate, pre-existing match-
+    # confidence heuristic in inspector.py's Rule 7 (contains_ci confidence
+    # scales with how much of the surrounding text the match covers) — not
+    # something this test is about, so accept either flagged status.
+    assert step["status"] in ("fail", "semantic_fail"), (
+        f"Node should be flagged, got {step['status']!r}. "
         "Check that the pattern is in the registry and the output contains it."
     )
 
@@ -255,7 +261,10 @@ def test_5_public_db_flags_next_run():
     """A shared signature in the cache flags the next run without LLM."""
     shared_pattern = "[SYSTEM PROMPT LEAKED]"
 
-    # Seed the shared cache directly (simulates a previously synced community sig)
+    # Seed the shared cache directly (simulates a previously synced community
+    # sig). approve_candidate_shared always promotes to critical on approval
+    # (a confirmed pattern, not a hedge), so a real synced entry is critical
+    # too — matching that here rather than the pre-approval "warning" hedge.
     cache = Path(".argus/shared_signatures_cache.json")
     cache.parent.mkdir(parents=True, exist_ok=True)
     cache.write_text(
@@ -265,7 +274,7 @@ def test_5_public_db_flags_next_run():
                 "category": "suspicious_phrases",
                 "pattern": shared_pattern,
                 "match_strategy": "contains_ci",
-                "severity": "warning",
+                "severity": "critical",
                 "description": "Detects leaked system prompt markers in RAG output",
                 "source": "shared",
             }
@@ -287,8 +296,10 @@ def test_5_public_db_flags_next_run():
     step = run["steps"][0]
 
     assert step["node_name"] == "rag_retriever"
-    assert step["status"] == "semantic_fail", (
-        f"Node should be semantic_fail, got {step['status']!r}"
+    # See test_3's comment — flagged status, exact value depends on a
+    # separate match-confidence heuristic.
+    assert step["status"] in ("fail", "semantic_fail"), (
+        f"Node should be flagged, got {step['status']!r}"
     )
 
     semantic_signals = step.get("inspection", {}).get("semantic_signals", [])
@@ -376,7 +387,9 @@ def test_7_full_loop_report(monkeypatch, capsys):
     run_a = _load_run(runs_dir_a)
     step_a = run_a["steps"][0]
     results["private_flags_without_llm"] = (
-        step_a["status"] == "semantic_fail"
+        # See test_3's comment — flagged status, exact value depends on a
+        # separate match-confidence heuristic.
+        step_a["status"] in ("fail", "semantic_fail")
         and len(step_a.get("inspection", {}).get("semantic_signals", [])) > 0
     )
 
@@ -431,7 +444,9 @@ def test_7_full_loop_report(monkeypatch, capsys):
     run_b = _load_run(runs_dir_a)
     step_b = run_b["steps"][0]
     results["public_flags_without_llm"] = (
-        step_b["status"] == "semantic_fail"
+        # See test_3's comment — flagged status, exact value depends on a
+        # separate match-confidence heuristic.
+        step_b["status"] in ("fail", "semantic_fail")
         and len(step_b.get("inspection", {}).get("semantic_signals", [])) > 0
     )
 

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -994,6 +994,58 @@ def test_latency_no_thresholds_no_flags():
     assert len(inspection.tool_failures) == 0
 
 
+# ── Semantic signal severity gates node status (issue #46) ────────────────────
+# A "warning" severity signature match (e.g. an ambiguous suspicious-phrase
+# hit) must not, on its own, fail a node — only "critical" severity does.
+# Before this fix any registry match at all flipped pass -> semantic_fail
+# regardless of severity.
+
+
+@pytest.mark.unit
+def test_warning_severity_signal_does_not_fail_node():
+    from argus.models import LLMInvestigationConfig
+
+    session = ArgusSession(llm_investigation=LLMInvestigationConfig(enabled=False))
+    session.set_node_names(["summarize"])
+
+    def node(state):
+        # PH-001 (placeholder_outputs, warning severity, exact_ci — fixed
+        # 1.0 match confidence): literal TODO placeholder left in output.
+        return {"result": "TODO"}
+
+    wrapped = session.wrap("summarize", node)
+    wrapped({"input": "doc"})
+    session.finalize()
+
+    loaded = load_run(session.run_id)
+    step = loaded.steps[0]
+    assert step.status == "pass"
+    assert any(s.sig_id == "PH-001" for s in step.inspection.semantic_signals)
+
+
+@pytest.mark.unit
+def test_critical_severity_signal_fails_node():
+    from argus.models import LLMInvestigationConfig
+
+    session = ArgusSession(llm_investigation=LLMInvestigationConfig(enabled=False))
+    session.set_node_names(["summarize"])
+
+    def node(state):
+        # PH-002 (placeholder_outputs, critical severity, exact_ci — fixed
+        # 1.0 match confidence, so it's unaffected by the length-based
+        # confidence heuristic that other match strategies apply).
+        return {"result": "PLACEHOLDER"}
+
+    wrapped = session.wrap("summarize", node)
+    wrapped({"input": "doc"})
+    session.finalize()
+
+    loaded = load_run(session.run_id)
+    step = loaded.steps[0]
+    assert step.status in ("fail", "semantic_fail")
+    assert any(s.sig_id == "PH-002" for s in step.inspection.semantic_signals)
+
+
 # ── Conditional branch skipping (VAR-61) ──────────────────────────────────────
 
 


### PR DESCRIPTION
Closes #46.

Right now, any match from the signature registry fails a node, no matter what severity it's marked as. A warning hit (like an ambiguous placeholder match) ends up failing the node exactly the same way a critical one does, which isn't really what "warning" is supposed to mean. This came up during review on PR #43.

Fixed the core logic in session.py so only critical severity signals actually flip a node's status now. Warnings still show up on the run for visibility, they just don't fail anything on their own anymore.

That change turned out to have a real side effect though: the learned-signature feature (where a pattern gets approved and then auto-flags future runs without needing an LLM call) was quietly depending on the old behavior, since candidates default to warning severity. So I updated approve_candidate and approve_candidate_shared in candidate_store.py to bump severity to critical the moment a human approves a candidate. Makes sense either way, once you've confirmed a pattern is real, it's not a hedge anymore. Kept the original suggested severity in the metadata for reference.

Updated the DB-flow tests to match, and added a couple of small focused tests just for the severity gate itself so this doesn't regress quietly again.