### PR TITLE
docs: point contributors at Discord before opening PRs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,6 +15,7 @@
 ## Checklist
 
 - [ ] I have read the [Contributing guide](../CONTRIBUTING.md).
+- [ ] I have joined the [ARGUS Discord](https://discord.gg/67XTFTDSgd) (updates, questions, PR discussion).
 - [ ] I have signed the [CLA](../CLA.md) (the bot will prompt on first PR).
 - [ ] My change targets the **open-source core** only — I have **not** modified
       `cloud/` or `supabase/` (proprietary; maintainer-only).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,12 @@
 
 Thanks for your interest in contributing. ARGUS is a production readiness platform for AI agent pipelines — there's a lot of surface area and we welcome help across the board.
 
+## Discord
+
+**Join the [ARGUS Discord](https://discord.gg/67XTFTDSgd) before opening a PR.**
+
+That is where we post updates, answer questions, and talk through PRs. GitHub is still the place issues and pull requests land — Discord is how you stay in the loop so you are not coding against a stale plan.
+
 ## Areas Where Contribution Is Needed
 
 ### Framework Adapters — Planned (Not Yet Open for PRs)
@@ -153,6 +159,7 @@ entire roadmap in one pass. If you're using one on this repo, hold it to the sam
 
 ## Pull Requests
 
+- Join the [Discord](https://discord.gg/67XTFTDSgd) before you open the PR
 - Keep PRs focused — one fix or feature per PR
 - For new detection logic, include a fixture run that the old code misses and the new code catches
 - Don't add co-author attribution in commits

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
   <a href="https://pypi.org/project/argus-agents/"><img src="https://img.shields.io/pypi/v/argus-agents" alt="PyPI version"/></a>
   <a href="https://pypi.org/project/argus-agents/"><img src="https://img.shields.io/badge/python-3.9%2B-blue" alt="Python 3.9+"/></a>
   <a href="https://github.com/VaradDurge/ARGUS/releases"><img src="https://img.shields.io/badge/status-beta-6366f1" alt="Beta"/></a>
+  <a href="https://discord.gg/67XTFTDSgd"><img src="https://img.shields.io/badge/Discord-join-5865F2?logo=discord&logoColor=white" alt="Discord"/></a>
 </div>
 
 ---
@@ -12,7 +13,7 @@
 
 Your LangGraph pipeline runs fine — no exception. But three nodes later, something crashes with a `KeyError`. The real cause? A node upstream silently dropped a field. ARGUS catches this.
 
-Beta, and under active development. ARGUS is early. Expect rough edges and bugs, and expect things to move. Issues and pull requests are welcome.
+Beta, and under active development. ARGUS is early. Expect rough edges and bugs, and expect things to move. Issues and pull requests are welcome. Contributors: join the [Discord](https://discord.gg/67XTFTDSgd) before opening a PR — that is where updates land.
 
 ---
 
@@ -345,6 +346,10 @@ For AI setup prompts and integration guides, visit **[arguslabs.in](https://argu
 ---
 
 **v0.8.12** — [changelog](https://github.com/VaradDurge/ARGUS/releases)
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md). Join the [Discord](https://discord.gg/67XTFTDSgd) before opening a PR for updates and to talk through the change.
 
 ## License
 


### PR DESCRIPTION
## Summary
- Discord invite in CONTRIBUTING (join before opening a PR), README badge + contributing section, and the PR checklist.

## Test plan
- [ ] Invite https://discord.gg/67XTFTDSgd still opens
- [ ] README badge and CONTRIBUTING Discord section are visible on GitHub


Made with [Cursor](https://cursor.com)