### PR TITLE
ci: run pytest --argus eat-own-cooking gate on every PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,3 +30,9 @@ jobs:
 
       - name: Test
         run: pytest --tb=short
+
+      # Eat our own cooking (#56): if pytest --argus regresses, this job goes red.
+      # Narrow gate only — do not dump --argus on the full suite (intentional
+      # silent-failure tests would fail the outer gate until #54 hardens binding).
+      - name: Test pytest --argus gate
+        run: pytest tests/test_argus_ci_gate.py --argus --tb=short

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,8 @@ argus diff <run-a> <run-b>
 argus replay <run-id> <node>
 argus ui
 pytest --argus                       # fail tests whose ARGUS run was not clean
+# CI eat-own-cooking gate (#56):
+# pytest tests/test_argus_ci_gate.py --argus
 ```
 
 ## Architecture
@@ -85,6 +87,7 @@ Every wrapped node executes through this pipeline:
 | `src/argus/check.py` | CI gate: evaluate a `RunRecord` as clean vs crash / silent_failure / semantic_fail |
 | `src/argus/cli/cmd_check.py` | `argus check <id>` / `ARGUS_RUN_ID=<id> argus check` / `argus check last` — grade one run, print its file, and exit 1 when it was not clean |
 | `src/argus/pytest_plugin.py` | pytest `--argus` plugin: fail tests whose instrumented run was not clean |
+| `tests/test_argus_ci_gate.py` | Narrow sync-invoke graph run under CI `pytest --argus` (eat-own-cooking; #56) |
 | `src/argus/cli/main.py` | `argus` CLI entry point (Typer) |
 | `src/argus/cli/cmd_doctor.py` | `argus doctor` diagnostic command |
 | `src/argus/findings.py` | `collect_findings()` — builds `RunRecord.findings`; also the one-line terminal summary after invoke |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -188,7 +188,8 @@ contributions**. PRs that modify them will be closed.
 ## Review & Merge Process
 
 - `master` is protected: **all changes land via pull request** — no direct pushes.
-- CI (ruff + pytest on Python 3.9/3.11/3.12) must pass.
+- CI (ruff + pytest on Python 3.9/3.11/3.12) must pass, including the
+  eat-own-cooking gate: `pytest tests/test_argus_ci_gate.py --argus`.
 - At least one **code owner** approval is required (see [CODEOWNERS](.github/CODEOWNERS)).
 - Only maintainers merge to `master`.
 

--- a/tests/test_argus_ci_gate.py
+++ b/tests/test_argus_ci_gate.py
@@ -31,7 +31,9 @@ def _clean_graph() -> StateGraph:
 
 
 def _require_argus(request: pytest.FixtureRequest) -> None:
-    if not request.config.getoption("--argus"):
+    # default=False: skip instead of crashing when the pytest11 plugin is not loaded
+    # (stale venv, or pytest without `pip install -e .`).
+    if not request.config.getoption("--argus", default=False):
         pytest.skip("requires pytest --argus (CI eat-own-cooking gate; see #56)")
 
 

--- a/tests/test_argus_ci_gate.py
+++ b/tests/test_argus_ci_gate.py
@@ -1,0 +1,54 @@
+"""CI eat-own-cooking gate: must pass under ``pytest --argus``.
+
+These tests intentionally rely on the pytest plugin's auto-instrumentation
+(no explicit ``ArgusWatcher``). They are skipped unless ``--argus`` is set so
+the default suite stays green; CI runs this file with ``--argus`` so a broken
+plugin (no attach / false positive) fails ARGUS's own pipeline.
+"""
+
+from __future__ import annotations
+
+from typing import TypedDict
+
+import pytest
+from langgraph.graph import END, StateGraph
+
+from argus.storage import last_run_id, list_runs, load_run
+
+pytest.importorskip("langgraph")
+
+
+class _Count(TypedDict):
+    n: int
+
+
+def _clean_graph() -> StateGraph:
+    g = StateGraph(_Count)
+    g.add_node("inc", lambda s: {"n": s["n"] + 1})
+    g.set_entry_point("inc")
+    g.add_edge("inc", END)
+    return g
+
+
+def _require_argus(request: pytest.FixtureRequest) -> None:
+    if not request.config.getoption("--argus"):
+        pytest.skip("requires pytest --argus (CI eat-own-cooking gate; see #56)")
+
+
+@pytest.mark.unit
+def test_ci_argus_gate_clean_sync_invoke_creates_clean_run(
+    request: pytest.FixtureRequest,
+) -> None:
+    """Sync invoke under --argus must produce a clean run (plugin must attach)."""
+    _require_argus(request)
+
+    before = {row["run_id"] for row in list_runs() if row.get("run_id")}
+    app = _clean_graph().compile()
+    assert app.invoke({"n": 0})["n"] == 1
+
+    run_id = last_run_id()
+    assert run_id is not None, "pytest --argus did not create a run (plugin attach broken?)"
+    assert run_id not in before, "expected a new run from this invoke"
+
+    record = load_run(run_id)
+    assert record.overall_status == "clean"


### PR DESCRIPTION
## What & why

ARGUS CI ran plain `pytest` and never exercised `pytest --argus`. If the plugin regresses, our own pipeline could stay green while users hit the flake first.

Adds a narrow sync-invoke LangGraph gate test and a CI step that runs it under `--argus`. The test asserts a new clean run was created (attach must work) and stays skipped in the default suite.

Closes #56

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / internal
- [ ] Docs
- [ ] Other:

## Checklist

- [x] I have read the [Contributing guide](../CONTRIBUTING.md).
- [x] I have signed the [CLA](../CLA.md) (the bot will prompt on first PR).
- [x] My change targets the **open-source core** only — I have **not** modified
      `cloud/` or `supabase/` (proprietary; maintainer-only).
- [x] Tests added/updated and `pytest` passes locally.
- [x] `ruff check .` passes.
- [x] Docs updated if behavior or the public API changed (`CLAUDE.md`, relevant docs).
- [ ] PR has a label (`bugfix`, `enhancement`, `refactor`, `investigation`, `documentation`, `dead-code`).

## Notes for reviewers

- Intentionally **not** `pytest --argus` on the full suite — intentional silent-failure tests would fail the outer gate until #54 hardens run binding.
- `.github/` is CODEOWNERS owner-only — needs @VaradDurge review.
- Please add label `enhancement`.
- Local: gate skips without `--argus`, passes with it; full suite 873 passed.